### PR TITLE
Minor fixes for the context menus

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
@@ -250,12 +250,11 @@ namespace WelsonJS.Launcher
             if (!Program.resourceServer.IsRunning())
             {
                 Program.resourceServer.Start();
-                ((ToolStripMenuItem)sender).Text = "Stop the code editor...";
+                ((ToolStripMenuItem)sender).Text = "Open the code editor...";
             }
             else
             {
-                Program.resourceServer.Stop();
-                ((ToolStripMenuItem)sender).Text = "Start the code editor...";
+                Program.OpenWebBrowser(Program.resourceServer.GetPrefix());
             }
         }
 
@@ -267,7 +266,7 @@ namespace WelsonJS.Launcher
             }
             else
             {
-                Process.Start(Program.resourceServer.GetPrefix());
+                Program.OpenWebBrowser(Program.resourceServer.GetPrefix());
             }
         }
 


### PR DESCRIPTION
Minor fixes for the context menu

## Summary by Sourcery

Refactor the code editor context menu to open the code editor in the web browser instead of starting and stopping the resource server. Rename the 'Stop the code editor...' text to 'Open the code editor...' when the resource server is running.

Enhancements:
- Open the code editor in the web browser instead of starting and stopping the resource server.
- Rename the 'Stop the code editor...' text to 'Open the code editor...' when the resource server is running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the code editor launch experience: When the server is running, selecting the editor option now opens your default web browser directly.
  - Updated the menu label for a clearer, more intuitive indication of the action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->