### PR TITLE
Add the mutex to avoid redundant

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
@@ -38,6 +38,7 @@ namespace WelsonJS.Launcher
             {
                 e.Cancel = true;
                 this.Hide();
+                this.ShowInTaskbar = false;
                 notifyIcon1.Visible = true;
             }
             base.OnFormClosing(e);
@@ -47,6 +48,7 @@ namespace WelsonJS.Launcher
         {
             this.Show();
             this.WindowState = FormWindowState.Normal;
+            this.ShowInTaskbar = true;
             this.Focus();
             notifyIcon1.Visible = false;
         }

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using WelsonJS.Launcher.Tools;
 
@@ -9,14 +10,24 @@ namespace WelsonJS.Launcher
 {
     internal static class Program
     {
+        static Mutex mutex;
         public static ResourceServer resourceServer;
 
         [STAThread]
         static void Main()
         {
+            mutex = new Mutex(true, "WelsonJS.Launcher.Mutex", out bool isMutexNotExists);
+            if (!isMutexNotExists)
+            {
+                MessageBox.Show("WelsonJS Launcher already running.");
+                return;
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new MainForm());
+
+            mutex.ReleaseMutex();
         }
 
         public static void RunCommandPrompt(string workingDirectory, string entryFileName, string scriptName, bool isConsoleApplication = false, bool isInteractiveServiceAapplication = false)

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
@@ -28,6 +28,7 @@ namespace WelsonJS.Launcher
             Application.Run(new MainForm());
 
             mutex.ReleaseMutex();
+            mutex.Dispose();
         }
 
         public static void RunCommandPrompt(string workingDirectory, string entryFileName, string scriptName, bool isConsoleApplication = false, bool isInteractiveServiceAapplication = false)

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/ResourceServer.cs
@@ -125,6 +125,14 @@ namespace WelsonJS.Launcher.Tools
                 return;
             }
 
+            // Serve TFA request
+            const string tfaPrefix = "tfa/";
+            if (path.StartsWith(tfaPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                ServeTfaRequest(context, path.Substring(tfaPrefix.Length - 1));
+                return;
+            }
+
             // Serve a resource
             ServeResource(context, GetResource(_resourceName), "text/html");
         }
@@ -249,6 +257,24 @@ namespace WelsonJS.Launcher.Tools
             {
                 ServeResource(context, $"<error>Failed to process DNS query. {ex.Message}</error>", "application/xml", 500);
             }
+        }
+
+        private void ServeTfaRequest(HttpListenerContext context, string endpoint)
+        {
+            Tfa _tfa = new Tfa();
+
+            if (endpoint.Equals("/pubkey"))
+            {
+                ServeResource(context, _tfa.GetPubKey(), "text/plain", 200);
+                return;
+            }
+
+            ServeResource(context);
+        }
+
+        private void ServeResource(HttpListenerContext context)
+        {
+            ServeResource(context, "<error>Not Found</error>", "application/xml", 404);
         }
 
         private void ServeResource(HttpListenerContext context, byte[] data, string mimeType = "text/html", int statusCode = 200)

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/ResourceServer.cs
@@ -105,7 +105,7 @@ namespace WelsonJS.Launcher.Tools
             const string devtoolsPrefix = "devtools/";
             if (path.StartsWith(devtoolsPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                await ServeDevTools(context, path.Substring(devtoolsPrefix.Length - 1));
+                await ServeDevTools(context, path.Substring(devtoolsPrefix.Length));
                 return;
             }
 
@@ -129,7 +129,7 @@ namespace WelsonJS.Launcher.Tools
             const string tfaPrefix = "tfa/";
             if (path.StartsWith(tfaPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                ServeTfaRequest(context, path.Substring(tfaPrefix.Length - 1));
+                ServeTfaRequest(context, path.Substring(tfaPrefix.Length));
                 return;
             }
 
@@ -178,7 +178,7 @@ namespace WelsonJS.Launcher.Tools
             {
                 using (HttpClient client = new HttpClient())
                 {
-                    string url = "http://localhost:9222" + endpoint;
+                    string url = "http://localhost:9222/" + endpoint;
                     string data = await client.GetStringAsync(url);
 
                     ServeResource(context, data, "application/json");
@@ -263,7 +263,7 @@ namespace WelsonJS.Launcher.Tools
         {
             Tfa _tfa = new Tfa();
 
-            if (endpoint.Equals("/pubkey"))
+            if (endpoint.Equals("pubkey"))
             {
                 ServeResource(context, _tfa.GetPubKey(), "text/plain", 200);
                 return;

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/Tfa.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/Tfa.cs
@@ -32,13 +32,19 @@ namespace WelsonJS.Launcher.Tools
 
         public string GetPubKey()
         {
-            var rand = new Random();
-            var key = new char[16];
-            for (int i = 0; i < 16; i++)
+            using (var rng = RandomNumberGenerator.Create())
             {
-                key[i] = Base32Chars[rand.Next(Base32Chars.Length)];
+                var key = new char[16];
+                var randomBytes = new byte[16];
+                rng.GetBytes(randomBytes);
+
+                for (int i = 0; i < 16; i++)
+                {
+                    key[i] = Base32Chars[randomBytes[i] % Base32Chars.Length];
+                }
+
+                return string.Join(" ", Enumerable.Range(0, 4).Select(i => new string(key, i * 4, 4)));
             }
-            return string.Join(" ", Enumerable.Range(0, 4).Select(i => new string(key, i * 4, 4)));
         }
 
         private static byte[] DecodeBase32(string key)

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/Tfa.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Tools/Tfa.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Collections.Generic;
+
+namespace WelsonJS.Launcher.Tools
+{
+    public class Tfa
+    {
+        private const string Base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+        public int GetOtp(string key)
+        {
+            byte[] binaryKey = DecodeBase32(key.Replace(" ", ""));
+            long timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / 30;
+            byte[] timestampBytes = BitConverter.GetBytes(timestamp);
+            Array.Reverse(timestampBytes); // Ensure big-endian order
+
+            using (var hmac = new HMACSHA1(binaryKey))
+            {
+                byte[] hash = hmac.ComputeHash(timestampBytes);
+                int offset = hash[hash.Length - 1] & 0xF;
+
+                int otp = ((hash[offset] & 0x7F) << 24) |
+                          ((hash[offset + 1] & 0xFF) << 16) |
+                          ((hash[offset + 2] & 0xFF) << 8) |
+                          (hash[offset + 3] & 0xFF);
+
+                return otp % 1000000; // Ensure 6-digit OTP
+            }
+        }
+
+        public string GetPubKey()
+        {
+            var rand = new Random();
+            var key = new char[16];
+            for (int i = 0; i < 16; i++)
+            {
+                key[i] = Base32Chars[rand.Next(Base32Chars.Length)];
+            }
+            return string.Join(" ", Enumerable.Range(0, 4).Select(i => new string(key, i * 4, 4)));
+        }
+
+        private static byte[] DecodeBase32(string key)
+        {
+            int buffer = 0, bitsLeft = 0;
+            var binaryKey = new List<byte>();
+
+            foreach (char c in key)
+            {
+                int value = Base32Chars.IndexOf(c);
+                if (value < 0) continue; // Ignore invalid characters
+
+                buffer = (buffer << 5) + value;
+                bitsLeft += 5;
+                if (bitsLeft >= 8)
+                {
+                    bitsLeft -= 8;
+                    binaryKey.Add((byte)((buffer >> bitsLeft) & 0xFF));
+                }
+            }
+            return binaryKey.ToArray();
+        }
+    }
+}

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
@@ -101,6 +101,7 @@
       <DependentUpon>GlobalSettingsForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Tools\ResourceServer.cs" />
+    <Compile Include="Tools\Tfa.cs" />
     <EmbeddedResource Include="EnvForm.resx">
       <DependentUpon>EnvForm.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
Add the mutex to avoid redundant

## Summary by Sourcery

Implements a mutex to prevent redundant instances of the launcher and adds support for serving two-factor authentication (TFA) requests.

New Features:
- Adds support for serving TFA requests via a new 'tfa/' endpoint, including a '/pubkey' sub-endpoint to retrieve a public key.
- Implements a mutex to prevent multiple instances of the application from running simultaneously.
- Hides the main form and shows a notification icon when the form is closing, preventing the application from fully exiting.
- Adds a Tfa class to generate and manage two-factor authentication keys and OTPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved window behavior: The application now automatically adjusts its display in the operating system’s taskbar during closing and reopening for a smoother experience.
  - Single-instance enforcement: The launcher prevents multiple simultaneous launches, notifying users if an instance is already running.
  - Enhanced security: New support for two-factor authentication now provides secure public key retrieval and one-time password generation.
  - New error handling for TFA requests ensures users receive appropriate responses for invalid endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->