### PR TITLE
Revert "Reduce SAS token period to 2 years"

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -5,7 +5,7 @@ REM Source code available: https://github.com/gnh1201/welsonjs
 pushd %~dp0
 
 :: Define variables
-set BLOB_SAS_TOKEN=sp=r^&st=2025-03-27T08:40:39Z^&se=2027-03-27T16:40:39Z^&spr=https^&sv=2024-11-04^&sr=b^&sig=4U4u72PN8BjSYDW6bNAGpjp6Y6M%%2F24OK18iNS1t4Kv0%%3D
+set BLOB_SAS_TOKEN=sp=r^&st=2025-03-27T07:49:26Z^&se=2035-03-27T15:49:26Z^&spr=https^&sv=2024-11-04^&sr=b^&sig=iQBsKk7lXwwdi0g2rY1KOD%%2Fi5zuG7PBlfGwmWaCJEBs%%3D
 set TOOLKIT_URL="https://catswords.blob.core.windows.net/welsonjs/welsonjs_toolkit_latest.cab?%BLOB_SAS_TOKEN%"
 set TOOLKIT_PATH=%APPDATA%\welsonjs\welsonjs_toolkit_latest.cab
 set TOOLKIT_EXTRACT_PATH=%APPDATA%\welsonjs


### PR DESCRIPTION
This reverts commit e930cf86fda800ffd6c22c89da9e295d48096ee9.

## Summary by Sourcery

Enhancements:
- Extended the Azure Blob SAS token validity period from 2 years to 10 years in the bootstrap script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal authentication credentials to ensure secure, extended, and reliable access to asset storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->