### PR TITLE
Change the remote blob server to localhost

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -258,14 +258,5 @@ namespace WelsonJS.Launcher.Properties {
                 return ResourceManager.GetString("WhoisServerUrl", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.3124.77과(와) 유사한 지역화된 문자열을 찾습니다.
-        /// </summary>
-        internal static string WhoisUserAgent {
-            get {
-                return ResourceManager.GetString("WhoisUserAgent", resourceCulture);
-            }
-        }
     }
 }

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace WelsonJS.Launcher.Properties {
         }
         
         /// <summary>
+        ///   https://catswords.blob.core.windows.net/welsonjs/과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string BlobServerPrefix {
+            get {
+                return ResourceManager.GetString("BlobServerPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   https://copilot.microsoft.com/과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
         internal static string CopilotUrl {

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
@@ -178,9 +178,6 @@
   <data name="WhoisServerUrl" xml:space="preserve">
     <value>https://xn--c79as89aj0e29b77z.xn--3e0b707e/kor/whois.jsc</value>
   </data>
-  <data name="WhoisUserAgent" xml:space="preserve">
-    <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.3124.77</value>
-  </data>
   <data name="BlobServerPrefix" xml:space="preserve">
     <value>https://catswords.blob.core.windows.net/welsonjs/</value>
   </data>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
@@ -181,4 +181,7 @@
   <data name="WhoisUserAgent" xml:space="preserve">
     <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.3124.77</value>
   </data>
+  <data name="BlobServerPrefix" xml:space="preserve">
+    <value>https://catswords.blob.core.windows.net/welsonjs/</value>
+  </data>
 </root>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -9,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Xml.Linq;
 
 namespace WelsonJS.Launcher
 {
@@ -132,8 +130,10 @@ namespace WelsonJS.Launcher
 
                     string blobServerPrefix = Program.GetAppConfig("BlobServerPrefix");
                     string url = $"{blobServerPrefix}{path}";
+                    string userAgent = Program.GetAppConfig("DefaultUserAgent");
 
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.UserAgent.ParseAdd(context.Request.UserAgent);
                     HttpResponseMessage response = await client.SendAsync(request);
 
                     if (!response.IsSuccessStatusCode)

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
@@ -22,7 +22,7 @@ namespace WelsonJS.Launcher
         private string _resourceName;
         private List<IResourceTool> _tools = new List<IResourceTool>();
         private const int _blobTimeout = 5000;
-        private static readonly HttpClient _blobClient = new HttpClient();
+        private readonly HttpClient _blobClient = new HttpClient();
 
         public ResourceServer(string prefix, string resourceName)
         {

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceTools/Whois.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceTools/Whois.cs
@@ -44,7 +44,7 @@ namespace WelsonJS.Launcher.ResourceTools
                 };
 
                 request.Headers.Add("Accept", "*/*");
-                request.Headers.Add("User-Agent", Program.GetAppConfig("WhoisUserAgent"));
+                request.Headers.Add("User-Agent", context.Request.UserAgent);
                 client.DefaultRequestHeaders.Referrer = new Uri(Program.GetAppConfig("WhoisReferrerUrl"));
 
                 try

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
@@ -9,7 +9,6 @@
     <add key="AzureAiServiceApiKey" value=""/>
     <add key="WhoisServerUrl" value="https://xn--c79as89aj0e29b77z.xn--3e0b707e/kor/whois.jsc"/>
     <add key="WhoisReferrerUrl" value="https://xn--c79as89aj0e29b77z.xn--3e0b707e/kor/whois/whois.jsp"/>
-    <add key="WhoisUserAgent" value="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.3124.77"/>
     <add key="WhoisClientAddress" value="141.101.82.1"/>
     <add key="DnsServerAddress" value="1.1.1.1"/>
     <add key="BlobServerPrefix" value="https://catswords.blob.core.windows.net/welsonjs/"/>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
@@ -12,6 +12,7 @@
     <add key="WhoisUserAgent" value="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.3124.77"/>
     <add key="WhoisClientAddress" value="141.101.82.1"/>
     <add key="DnsServerAddress" value="1.1.1.1"/>
+    <add key="BlobServerPrefix" value="https://catswords.blob.core.windows.net/welsonjs/"/>
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
@@ -3,9 +3,9 @@
 <head>
     <title>WelsonJS Editor</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <link rel="stylesheet" href="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/metroui/dev/lib/metro.css" integrity="sha384-4XgOiXH2ZMaWt5s5B35yKi7EAOabhZvx7wO8Jr71q2vZ+uONdRza/6CsK2kpyocd" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/metroui/dev/lib/icons.css" integrity="sha384-FuLND994etg+RtnpPSPMyNBvL+fEz+xGhbN61WUWuDEeZ+wJzcQ8SGqAMuI5hWrt" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.css" integrity="sha384-06yHXpYRlHEPaR4AS0fB/W+lMN09Zh5e1XMtfkNQdHV38OlhfkOEW5M+pCj3QskC" crossorigin="anonymous">
+    <link rel="stylesheet" href="http://localhost:3000/ajax/libs/metroui/dev/lib/metro.css" integrity="sha384-4XgOiXH2ZMaWt5s5B35yKi7EAOabhZvx7wO8Jr71q2vZ+uONdRza/6CsK2kpyocd" crossorigin="anonymous">
+    <link rel="stylesheet" href="http://localhost:3000/ajax/libs/metroui/dev/lib/icons.css" integrity="sha384-FuLND994etg+RtnpPSPMyNBvL+fEz+xGhbN61WUWuDEeZ+wJzcQ8SGqAMuI5hWrt" crossorigin="anonymous">
+    <link rel="stylesheet" href="http://localhost:3000/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.css" integrity="sha384-06yHXpYRlHEPaR4AS0fB/W+lMN09Zh5e1XMtfkNQdHV38OlhfkOEW5M+pCj3QskC" crossorigin="anonymous">
     <style>
         html, body {
             margin: 0;
@@ -85,16 +85,16 @@
     <script>
         var require = {
             paths: {
-                vs: 'https://catswords.blob.core.windows.net/welsonjs/ajax/libs/monaco-editor/0.52.2/min/vs'
+                vs: 'http://localhost:3000/ajax/libs/monaco-editor/0.52.2/min/vs'
             }
         };
     </script>
-    <script src="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/axios/1.8.4/axios.min.js" integrity="sha384-06w+raHvkSL3+E7mbQ2X6DZwI5A3veU8Ba+NLrAPxxRGw4Xy78sihHDHQMustMM4" crossorigin="anonymous"></script>
-    <script src="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/fast-xml-parser/4.5.1/fxparser.min.js" integrity="sha384-ae/HepOQ8hiJ/VA6yGwPMGXQXOkT/lJpjlcQ7EUgibUcfnBltuozgNj4IgOZ9QLc" crossorigin="anonymous"></script>
-    <script src="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/dompurify/3.2.4/purify.min.js" integrity="sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu" crossorigin="anonymous"></script>
-    <script src="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/metroui/dev/lib/metro.js" integrity="sha384-grz4KlnFmdCd5ELenGIdPkUL/l+44UC4SniSke/OZQyRYXaQ1EDlGigacn6z4hGB" crossorigin="anonymous"></script>
-    <script src="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/monaco-editor/0.52.2/min/vs/loader.js" integrity="sha384-pHG02SG8pId94Np3AbPmBEJ1yPqaH0IkJGLSNGXYmuGhkazT8Lr/57WYpbkGjJtu" crossorigin="anonymous"></script>
-    <script src="https://catswords.blob.core.windows.net/welsonjs/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.js" integrity="sha384-fj9z+NUc93I3woCCy5IRQfrQ8Amu1E27tllwgb5gz3d9Vr1ymS13xcF6two3e4KH" crossorigin="anonymous"></script>
+    <script src="http://localhost:3000/ajax/libs/axios/1.8.4/axios.min.js" integrity="sha384-06w+raHvkSL3+E7mbQ2X6DZwI5A3veU8Ba+NLrAPxxRGw4Xy78sihHDHQMustMM4" crossorigin="anonymous"></script>
+    <script src="http://localhost:3000/ajax/libs/fast-xml-parser/4.5.1/fxparser.min.js" integrity="sha384-ae/HepOQ8hiJ/VA6yGwPMGXQXOkT/lJpjlcQ7EUgibUcfnBltuozgNj4IgOZ9QLc" crossorigin="anonymous"></script>
+    <script src="http://localhost:3000/ajax/libs/dompurify/3.2.4/purify.min.js" integrity="sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu" crossorigin="anonymous"></script>
+    <script src="http://localhost:3000/ajax/libs/metroui/dev/lib/metro.js" integrity="sha384-grz4KlnFmdCd5ELenGIdPkUL/l+44UC4SniSke/OZQyRYXaQ1EDlGigacn6z4hGB" crossorigin="anonymous"></script>
+    <script src="http://localhost:3000/ajax/libs/monaco-editor/0.52.2/min/vs/loader.js" integrity="sha384-pHG02SG8pId94Np3AbPmBEJ1yPqaH0IkJGLSNGXYmuGhkazT8Lr/57WYpbkGjJtu" crossorigin="anonymous"></script>
+    <script src="http://localhost:3000/ajax/libs/monaco-editor/0.52.2/min/vs/editor/editor.main.js" integrity="sha384-fj9z+NUc93I3woCCy5IRQfrQ8Amu1E27tllwgb5gz3d9Vr1ymS13xcF6two3e4KH" crossorigin="anonymous"></script>
     <script>
         var editor;
         var currentFileName = "sayhello.js";


### PR DESCRIPTION
Change the remote blob server to localhost

## Summary by Sourcery

Change the remote blob server from Azure to a local development server

Enhancements:
- Modify resource server to support serving resources from a local blob server instead of the remote Azure blob server

Chores:
- Update resource URLs in editor.html to point to localhost
- Remove hardcoded user agent from resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new resource string for accessing blob storage.
- **Bug Fixes**
	- Removed outdated user agent configuration, ensuring cleaner resource management.
- **Chores**
	- Updated configuration settings to reflect new blob storage references.
	- Revised editor links to load external assets from a local server for improved development reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->