### PR TITLE
Forward Whois and DNS query data to LLM services

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
@@ -80,7 +80,7 @@
                         <span class="icon mif-earth"></span>
                         <span class="caption">DNS</span>
                     </button>
-                    <span class="title">Network</span>
+                    <span class="title">Network tools</span>
                 </div>
             </div>
         </div>
@@ -371,6 +371,7 @@
             axios.get(`${serverPrefix}whois/${hostname}`).then(response => {
                 const responseText = DOMPurify.sanitize(response.data, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
                 appendTextToEditor(`/*\n${responseText}\n*/`);
+                pushPromptMessage("system", responseText);
             }).catch(error => {
                 console.error(error);
             });
@@ -386,6 +387,7 @@
             axios.get(`${serverPrefix}dns-query/${hostname}`).then(response => {
                 const responseText = response.data;
                 appendTextToEditor(`/*\n${responseText}\n*/`);
+                pushPromptMessage("system", responseText);
             }).catch(error => {
                 console.error(error);
             });


### PR DESCRIPTION
Forward Whois and DNS query data to LLM services (e.g. Server configuration assistant)

## Summary by Sourcery

Enhance network tools by forwarding Whois and DNS query results to LLM services for additional context and analysis

New Features:
- Add capability to send Whois and DNS query data to LLM services for enhanced information processing

Enhancements:
- Modify network tools to automatically push Whois and DNS query results to the system prompt, enabling LLM-assisted analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Revised the title text for clarity, updating it to "Network tools" in the user interface.
- **New Features**
	- Improved handling of data feedback from external sources to provide a more responsive and informative experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->