### PR TITLE
Fix bug when use DevTools CORS policy (WebSocket error)

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
@@ -155,6 +155,7 @@ namespace WelsonJS.Launcher
 
             string userDataDir = Path.Combine(GetAppDataPath(), "EdgeUserProfile");
             string remoteAllowOrigins = $"{resourceServerUri.Scheme}://{resourceServerUri.Host}:{resourceServerUri.Port}";
+            int remoteDebuggingPort = devToolsUri.Port;
             string[] arguments = {
                 $"\"{url}\"",
                 $"--remote-debugging-port={remoteDebuggingPort}",

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
@@ -150,9 +150,11 @@ namespace WelsonJS.Launcher
         }
         public static void OpenWebBrowser(string url)
         {
+            Uri resourceServerUri = new Uri(GetAppConfig("ResourceServerPrefix"));
+            Uri devToolsUri = new Uri(GetAppConfig("DevToolsPrefix"));
+
             string userDataDir = Path.Combine(GetAppDataPath(), "EdgeUserProfile");
-            string remoteAllowOrigins = GetAppConfig("ResourceServerPrefix");
-            int remoteDebuggingPort = new Uri(GetAppConfig("DevToolsPrefix")).Port;
+            string remoteAllowOrigins = $"{resourceServerUri.Scheme}://{resourceServerUri.Host}:{resourceServerUri.Port}";
             string[] arguments = {
                 $"\"{url}\"",
                 $"--remote-debugging-port={remoteDebuggingPort}",

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
@@ -395,7 +395,7 @@
                         if (response.id == 3) {
                             const responseContent = response.result.result.value;
 
-                            appendTextToEditor(responseContent);
+                            appendTextToEditor("/*\n" + responseContent + "\n*/");
                             pushPromptMessage("assistant", responseContent);
 
                             socket.close();


### PR DESCRIPTION
Fix bug when use DevTools CORS policy (WebSocket error)

## Summary by Sourcery

Fix CORS policy and WebSocket handling in DevTools integration

Bug Fixes:
- Corrected the CORS origin configuration by properly constructing the resource server origin
- Modified WebSocket response handling to wrap assistant responses in comment blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of configuration values for web browser launching to ensure more reliable parsing and usage of server addresses.
  - Response content from specific WebSocket messages is now wrapped in a multi-line comment block before being added to the editor, enhancing readability and preventing unintended code execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->