### PR TITLE
Remove the dependency `System.IO.Compression.ZipFile` #254

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
@@ -141,7 +141,7 @@ namespace WelsonJS.Launcher
                         // follow the sub-directory
                         workingDirectory = Program.GetWorkingDirectory(instanceId, true);
 
-                        // Run the appliction
+                        // Run the application
                         Program.RunCommandPrompt(workingDirectory, entryFileName, scriptName, cbUseSpecificScript.Checked, cbInteractiveServiceApp.Checked);
                     }
                 }

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Security.Principal;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -12,11 +11,14 @@ namespace WelsonJS.Launcher
     {
         private string workingDirectory;
         private string instanceId;
-        private string entryFileName;
+        private readonly string entryFileName;
         private string scriptName;
+        private readonly ZipExtractor zipExtractor;
 
         public MainForm()
         {
+            zipExtractor = new ZipExtractor();
+
             entryFileName = "bootstrap.bat";
 
             InitializeComponent();
@@ -130,17 +132,18 @@ namespace WelsonJS.Launcher
                         Directory.Delete(workingDirectory, true);
                     }
 
-                    // try to extact ZIP file
-                    ZipFile.ExtractToDirectory(filePath, workingDirectory);
+                    // try to extact ZIP compressed file
+                    if (zipExtractor.Extract(filePath, workingDirectory))
+                    {
+                        // record the first deploy time
+                        RecordFirstDeployTime(workingDirectory);
 
-                    // record the first deploy time
-                    RecordFirstDeployTime(workingDirectory);
+                        // follow the sub-directory
+                        workingDirectory = Program.GetWorkingDirectory(instanceId, true);
 
-                    // follow the sub-directory
-                    workingDirectory = Program.GetWorkingDirectory(instanceId, true);
-
-                    // Run the appliction
-                    Program.RunCommandPrompt(workingDirectory, entryFileName, scriptName, cbUseSpecificScript.Checked, cbInteractiveServiceApp.Checked);
+                        // Run the appliction
+                        Program.RunCommandPrompt(workingDirectory, entryFileName, scriptName, cbUseSpecificScript.Checked, cbInteractiveServiceApp.Checked);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
@@ -56,17 +56,12 @@
     <ApplicationIcon>favicon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
@@ -107,6 +102,7 @@
       <DependentUpon>GlobalSettingsForm.cs</DependentUpon>
     </Compile>
     <Compile Include="ResourceServer.cs" />
+    <Compile Include="ZipExtractor.cs" />
     <EmbeddedResource Include="EnvForm.resx">
       <DependentUpon>EnvForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -125,7 +121,6 @@
       <DependentUpon>GlobalSettingsForm.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="app.config" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -176,13 +176,19 @@ namespace WelsonJS.Launcher
             if (zip == null || dest == null)
                 return false;
 
+            int expected = zip.Items().Count;
             dest.CopyHere(zip.Items(), 16);
-
+            
+            // wait (max 30 s) until all files appear
+            var sw = Stopwatch.StartNew();
+            while (dest.Items().Count < expected && sw.Elapsed < TimeSpan.FromSeconds(30))
+                System.Threading.Thread.Sleep(200);
+            
             Marshal.ReleaseComObject(zip);
             Marshal.ReleaseComObject(dest);
             Marshal.ReleaseComObject(shell);
-
-            return true;
+            
+            return dest.Items().Count == expected;
         }
     }
 }

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -170,7 +170,10 @@ namespace WelsonJS.Launcher
                 return false;
 
             dynamic shell = Activator.CreateInstance(shellAppType);
+            if (shell == null)
+                return false;
             dynamic zip = shell.NameSpace(filePath);
+            dynamic dest = shell.NameSpace(workingDirectory);
             dynamic dest = shell.NameSpace(workingDirectory);
 
             if (zip == null || dest == null)

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -92,9 +92,6 @@ namespace WelsonJS.Launcher
 
         private bool IsValidFile(string filePath)
         {
-            if (!File.Exists(filePath))
-                throw new FileNotFoundException("File does not exist.", filePath);
-
             byte[] signature = new byte[4];
 
             using (var fs = File.OpenRead(filePath))
@@ -165,17 +162,15 @@ namespace WelsonJS.Launcher
         private bool ExtractUsingShell(string filePath, string workingDirectory)
         {
             var shellAppType = Type.GetTypeFromProgID("Shell.Application");
-
             if (shellAppType == null)
                 return false;
 
             dynamic shell = Activator.CreateInstance(shellAppType);
             if (shell == null)
                 return false;
+
             dynamic zip = shell.NameSpace(filePath);
             dynamic dest = shell.NameSpace(workingDirectory);
-            dynamic dest = shell.NameSpace(workingDirectory);
-
             if (zip == null || dest == null)
                 return false;
 

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace WelsonJS.Launcher
+{
+    public class ZipExtractor
+    {
+        class Extractor
+        {
+            public string Name;
+            public string Path;
+            public Func<string, string, string> ExtractCommand;
+        }
+
+        private readonly List<Extractor> AvailableExtractors;
+
+        public ZipExtractor()
+        {
+            AvailableExtractors = new List<Extractor>{
+                new Extractor
+                {
+                    Name = "7z",
+                    Path = FindExecutable("7z.exe"),
+                    ExtractCommand = (src, dest) => $"x \"{src}\" -o\"{dest}\" -y"
+                },
+                new Extractor
+                {
+                    Name = "WinRAR",
+                    Path = FindExecutable("rar.exe"),
+                    ExtractCommand = (src, dest) => $"x -o+ \"{src}\" \"{dest}\\\""
+                },
+                new Extractor
+                {
+                    Name = "PeaZip",
+                    Path = FindExecutable("peazip.exe"),
+                    ExtractCommand = (src, dest) => $"-ext2simple \"{src}\" \"{dest}\""
+                },
+                new Extractor
+                {
+                    Name = "tar (Windows)",
+                    Path = FindExecutable("tar.exe"),
+                    ExtractCommand = (src, dest) => $"-xf \"{src}\" -C \"{dest}\""
+                },
+                new Extractor
+                {
+                    Name = "WinZip",
+                    Path = FindExecutable("wzunzip.exe"),
+                    ExtractCommand = (src, dest) => $"-d \"{dest}\" \"{src}\""
+                },
+                new Extractor
+                {
+                    Name = "ALZip",
+                    Path = FindExecutable("ALZipcon.exe"),
+                    ExtractCommand = (src, dest) => $"-x \"{src}\" \"{dest}\""
+                },
+                new Extractor
+                {
+                    Name = "Bandizip",
+                    Path = FindExecutable("Bandizip.exe"),
+                    ExtractCommand = (src, dest) => $"x -o:\"{dest}\" \"{src}\" -y"
+                }
+            };
+        }
+
+        public bool Extract(string filePath, string workingDirectory)
+        {
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException("The specified file does not exist.", filePath);
+
+            if (!filePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("The specified file is not a ZIP archive.");
+
+            if (!IsValidFile(filePath))
+                throw new InvalidDataException("The specified file is not a valid ZIP archive.");
+
+            Directory.CreateDirectory(workingDirectory);
+
+            var extractor = AvailableExtractors.FirstOrDefault(e => e.Path != null);
+            if (extractor != null)
+            {
+                return RunProcess(extractor.Path, extractor.ExtractCommand(filePath, workingDirectory));
+            }
+
+            return ExtractUsingShell(filePath, workingDirectory);
+        }
+
+        private bool IsValidFile(string filePath)
+        {
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException("File does not exist.", filePath);
+
+            byte[] signature = new byte[4];
+
+            using (var fs = File.OpenRead(filePath))
+            {
+                if (fs.Length < 4)
+                    return false;
+
+                int bytesRead = fs.Read(signature, 0, 4);
+                if (bytesRead < 4)
+                    return false;
+            }
+
+            return signature.SequenceEqual(new byte[] { 0x50, 0x4B, 0x03, 0x04 });
+        }
+
+        private string FindExecutable(string executableFileName)
+        {
+            var paths = (Environment.GetEnvironmentVariable("PATH") ?? "").Split(';');
+            foreach (var dir in paths)
+            {
+                var full = Path.Combine(dir.Trim(), executableFileName);
+                if (File.Exists(full))
+                    return full;
+            }
+
+            // Check common install locations
+            var programDirs = new[]
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+            };
+
+            foreach (var dir in programDirs)
+            {
+                try
+                {
+                    var found = Directory.EnumerateFiles(dir, executableFileName, SearchOption.AllDirectories).FirstOrDefault();
+                    if (found != null)
+                        return found;
+                }
+                catch { }
+            }
+
+            return null;
+        }
+
+        private bool RunProcess(string filePath, string arguments)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = filePath,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using (var process = Process.Start(psi))
+            {
+                process.WaitForExit();
+
+                if (process.ExitCode != 0)
+                {
+                    string errorOutput = process.StandardError.ReadToEnd();
+                    throw new InvalidOperationException(
+                        $"Process '{filePath}' exited with code {process.ExitCode}. Error output: {errorOutput}");
+                }
+            }
+
+            return true;
+        }
+
+        private bool ExtractUsingShell(string filePath, string workingDirectory)
+        {
+            var shellAppType = Type.GetTypeFromProgID("Shell.Application");
+            dynamic shell = Activator.CreateInstance(shellAppType);
+            dynamic zip = shell.NameSpace(filePath);
+            dynamic dest = shell.NameSpace(workingDirectory);
+
+            if (zip == null || dest == null)
+                return false;
+
+            dest.CopyHere(zip.Items(), 16);
+
+            Marshal.ReleaseComObject(zip);
+            Marshal.ReleaseComObject(dest);
+            Marshal.ReleaseComObject(shell);
+
+            return true;
+        }
+    }
+}

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/packages.config
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
Remove the dependency `System.IO.Compression.ZipFile`

It will be fix the potentially license conflct issue from the `System.IO.Compression.ZipFile` package.

## Summary by Sourcery

Remove the built-in ZipFile dependency and implement a custom extraction utility that uses available CLI tools or shell integration to extract ZIP archives.

New Features:
- Add ZipExtractor class to handle ZIP extraction using external tools or shell COM

Enhancements:
- Swap out System.IO.Compression.ZipFile calls for ZipExtractor.Extract in the launcher
- Remove the System.IO.Compression.ZipFile package reference and related using directives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for extracting ZIP files using various external extraction tools (7-Zip, WinRAR, PeaZip, and more), with automatic fallback to Windows built-in extraction if no external tool is available.
  - Extraction now only proceeds if the ZIP file is valid and successfully extracted.

- **Chores**
  - Updated project dependencies and removed unused package references related to ZIP extraction.
  - Removed the packages configuration file to streamline dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->