### PR TITLE
One more fix #254

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
@@ -144,6 +144,10 @@ namespace WelsonJS.Launcher
                         // Run the application
                         Program.RunCommandPrompt(workingDirectory, entryFileName, scriptName, cbUseSpecificScript.Checked, cbInteractiveServiceApp.Checked);
                     }
+                    else
+                    {
+                        MessageBox.Show("Failed to extract the ZIP file.");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -194,14 +194,8 @@ namespace WelsonJS.Launcher
         {
             int exitCode = -1;
 
-            string fileName = execFilePath;
-            string adjustedArguments = arguments;
-
-            if (useCmd && !String.IsNullOrEmpty(workingDirectory))
-            {
-                fileName = "cmd.exe";
-                adjustedArguments = $"/c cd /d \"{workingDirectory}\" && \"{execFilePath}\" {arguments}";
-            }
+            string fileName = useCmd ? "cmd.exe" : execFilePath;
+            string adjustedArguments = useCmd ? $"/c \"{execFilePath}\" {arguments}" : arguments;
 
             var psi = new ProcessStartInfo
             {
@@ -222,13 +216,9 @@ namespace WelsonJS.Launcher
             }
 
             if (exitCode != 0)
-            {
                 Trace.TraceWarning($"{fileName} exit with code {exitCode}");
-            }
             else
-            {
                 Trace.TraceInformation($"{fileName} finished successfully");
-            }
 
             return exitCode == 0;
         }

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -64,7 +64,7 @@ namespace WelsonJS.Launcher
                 {
                     Name = "jar (Java SDK)",
                     FileName = "jar.exe",
-                    ExtractCommand = (src, dest) => $"jar xf \"{src}\"",
+                    ExtractCommand = (src, dest) => $"xf \"{src}\"",
                     UseCmd = true
                 },
                 new Extractor
@@ -190,7 +190,7 @@ namespace WelsonJS.Launcher
             if (useCmd && !String.IsNullOrEmpty(workingDirectory))
             {
                 fileName = "cmd.exe";
-                adjustedArguments = $"/c cd /d \"{workingDirectory}\" && {arguments}";
+                adjustedArguments = $"/c cd /d \"{workingDirectory}\" && \"{executableFilePath}\" {arguments}";
             }
 
             var psi = new ProcessStartInfo

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ZipExtractor.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 
 namespace WelsonJS.Launcher


### PR DESCRIPTION
One more fix #254

## Summary by Sourcery

Enable flexible extraction by allowing extractors to run via cmd.exe, add support for Java jar archives, and improve error logging and working directory handling

New Features:
- Add new extractor for jar.exe (Java SDK) with cmd-based extraction

Enhancements:
- Introduce UseCmd flag and refactor RunProcess to handle cmd.exe execution and working directory
- Log ignored file or directory errors in CheckAvailableExtractors using Trace.TraceInformation
- Include working directory context when invoking extraction commands (including PowerShell)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for extraction using Java SDK's `jar.exe`.
  - Enhanced extraction process to allow running commands via `cmd.exe` when needed.
- **Bug Fixes**
  - Improved error logging during extractor path discovery for better troubleshooting.
  - Added user notification when ZIP file extraction fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->