### PR TITLE
Criminal IP (criminalip.io) integration to WelsonJS Editor

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -106,6 +106,24 @@ namespace WelsonJS.Launcher.Properties {
         }
         
         /// <summary>
+        ///   과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string CitiApiKey {
+            get {
+                return ResourceManager.GetString("CitiApiKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   https://api.criminalip.io/v1/과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string CitiApiPrefix {
+            get {
+                return ResourceManager.GetString("CitiApiPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   https://copilot.microsoft.com/과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
         internal static string CopilotUrl {

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
@@ -190,4 +190,10 @@
   <data name="HttpClientTimeout" xml:space="preserve">
     <value>90</value>
   </data>
+  <data name="CitiApiKey" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CitiApiPrefix" xml:space="preserve">
+    <value>https://api.criminalip.io/v1/</value>
+  </data>
 </root>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
@@ -56,6 +56,7 @@ namespace WelsonJS.Launcher
             _tools.Add(new ResourceTools.Settings(this, _httpClient));
             _tools.Add(new ResourceTools.DevTools(this, _httpClient));
             _tools.Add(new ResourceTools.DnsQuery(this, _httpClient));
+            _tools.Add(new ResourceTools.CitiQuery(this, _httpClient));
             _tools.Add(new ResourceTools.Tfa(this, _httpClient));
             _tools.Add(new ResourceTools.Whois(this, _httpClient));
         }
@@ -367,6 +368,11 @@ namespace WelsonJS.Launcher
             else if (mimeType == "application/xml" && !data.StartsWith("<?xml"))
             {
                 data = xmlHeader + "\r\n" + data;
+            }
+            else if (mimeType == "application/json")
+            {
+                data = xmlHeader + "\r\n<json><![CDATA[" + data + "]]></json>";
+                mimeType = "application/xml";
             }
 
             ServeResource(context, Encoding.UTF8.GetBytes(data), mimeType, statusCode);

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceTools/CitiQuery.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceTools/CitiQuery.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Net.Http;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace WelsonJS.Launcher.ResourceTools
+{
+    public class CitiQuery : IResourceTool
+    {
+        private readonly ResourceServer Server;
+        private readonly HttpClient _httpClient;
+        private const string Prefix = "citi-query/";
+
+        public CitiQuery(ResourceServer server, HttpClient httpClient)
+        {
+            Server = server;
+            _httpClient = httpClient;
+        }
+
+        public bool CanHandle(string path)
+        {
+            return path.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public async Task HandleAsync(HttpListenerContext context, string path)
+        {
+            try
+            {
+                string target = path.Substring(Prefix.Length).Trim();
+                string apiKey = Program.GetAppConfig("CitiApiKey");
+                if (string.IsNullOrEmpty(apiKey))
+                {
+                    Server.ServeResource(context, "<error>Missing API key<error>", "application/xml", 500);
+                    return;
+                }
+
+                string encoded = Uri.EscapeDataString(target);
+                string apiPrefix = Program.GetAppConfig("CitiApiPrefix");
+                string url = $"{apiPrefix}asset/ip/report?ip={encoded}&full=true";
+
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.Add("x-api-key", apiKey);
+                request.Headers.Add("User-Agent", context.Request.UserAgent);
+
+                HttpResponseMessage response = await _httpClient.SendAsync(request);
+                string content = await response.Content.ReadAsStringAsync();
+
+                context.Response.StatusCode = (int)response.StatusCode;
+                Server.ServeResource(context, content, "application/json", (int)response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                Server.ServeResource(context, $"<error>{ex.Message}</error>", "application/xml", 500);
+            }
+        }
+    }
+}

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IResourceTool.cs" />
+    <Compile Include="ResourceTools\CitiQuery.cs" />
     <Compile Include="ResourceTools\Settings.cs" />
     <Compile Include="ResourceTools\Completion.cs" />
     <Compile Include="ResourceTools\DevTools.cs" />

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
@@ -15,6 +15,8 @@
     <add key="BlobStoragePrefix" value="https://catswords.blob.core.windows.net/welsonjs/"/>
     <add key="BlobConfigUrl" value="https://catswords.blob.core.windows.net/welsonjs/blob.config.xml"/>
     <add key="HttpClientTimeout" value="90"/>
+    <add key="CitiApiKey" value=""/>
+    <add key="CitiApiPrefix" value="https://api.criminalip.io/v1/"/>
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
@@ -119,7 +119,8 @@
 
             function RibbonMenu({
                 onOpenFileClick, onSaveFileClick, onCopliotClick, onAzureAiClick,
-                onSavePromptClick, onLoadPromptClick, onQueryWhoisClick, onQueryDnsClick
+                onSavePromptClick, onLoadPromptClick, onQueryWhoisClick, onQueryDnsClick,
+                onQueryCitiClick
             }) {
                 const fileButtons = [
                     {
@@ -145,7 +146,8 @@
 
                 const networkToolsButtons = [
                     { id: 'btnWhois', icon: 'mif-earth', caption: 'Whois', onClick: onQueryWhoisClick },
-                    { id: 'btnDnsQuery', icon: 'mif-earth', caption: 'DNS', onClick: onQueryDnsClick }
+                    { id: 'btnQueryDns', icon: 'mif-earth', caption: 'DNS', onClick: onQueryDnsClick },
+                    { id: 'btnQueryCiti', icon: 'mif-user-secret', caption: 'IP', onClick: onQueryCitiClick }
                 ];
 
                 return _e(
@@ -465,6 +467,11 @@
                     pushPromptMessage("user", promptMessage);
 
                     const apiKey = settingsRef.current.AzureAiServiceApiKey;
+                    if (!apiKey || apiKey.trim() == '') {
+                        alert("Azure AI API key is not set.");
+                        return;
+                    }
+
                     const url = `${settingsRef.current.AzureAiServicePrefix}models/chat/completions?api-version=${settingsRef.current.AzureAiServiceApiVersion}`;
 
                     const data = {
@@ -537,7 +544,7 @@
 
                     axios.get(`${serverPrefix}whois/${hostname}`).then(response => {
                         const responseText = DOMPurify.sanitize(response.data, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
-                        appendTextToEditor(`/*\n${responseText}\n*/`);
+                        appendTextToEditor(`/*\nHostname:${hostname}\n\n${responseText}\n*/`);
                         pushPromptMessage("system", responseText);
                     }).catch(error => {
                         console.error(error);
@@ -553,10 +560,75 @@
 
                     axios.get(`${serverPrefix}dns-query/${hostname}`).then(response => {
                         const responseText = response.data;
-                        appendTextToEditor(`/*\n${responseText}\n*/`);
+                        appendTextToEditor(`/*\nHostname:${hostname}\n\n${responseText}\n*/`);
                         pushPromptMessage("system", responseText);
                     }).catch(error => {
                         console.error(error);
+                    });
+                };
+
+                const queryCiti = () => {
+                    const hostname = prompt("Enter IP address:", '');
+                    if (!hostname || hostname.trim() === '') {
+                        appendTextToEditor("\n// IP address is required.");
+                        return;
+                    }
+
+                    const apiKey = settingsRef.current.CitiApiKey;
+                    if (!apiKey || apiKey.trim() === '') {
+                        appendTextToEditor("\n// Criminal IP API key is not set.");
+                        return;
+                    }
+
+                    const apiPrefix = settingsRef.current.CitiApiPrefix;
+                    const ip = encodeURIComponent(hostname.trim());
+
+                    axios.get(`${serverPrefix}citi-query/${hostname}`).then(response => {
+                        const parser = new XMLParser();
+                        const result = parser.parse(response.data);
+                        const data = JSON.parse(result.json);
+                        if (!data) {
+                            appendTextToEditor("\n// No data returned from Criminal IP.");
+                            return;
+                        }
+
+                        const lines = [];
+                        lines.push(`/*\nCriminal IP Report: ${hostname}\n`);
+                        
+                        // network port data
+                        lines.push(`## Network ports:`);
+                        if (data.port.data.length == 0) {
+                            lines.push(`* No open ports found.`);
+                        } else {
+                            data.port.data.forEach(x => {
+                                lines.push(`### ${x.open_port_no}/${x.socket}`);
+                                lines.push(`* Application: ${x.app_name} ${x.app_version}`);
+                                lines.push(`* Discovered hostnames: ${x.dns_names}`);
+                                lines.push(`* Confirmed Time: ${x.confirmed_time}`);
+                            });
+                        }
+
+                        // vulnerability data
+                        lines.push(`## Vulnerabilities:`);
+                        if (data.vulnerability.data.length == 0) {
+                            lines.push(`* No vulnerabilities found.`);
+                        } else {
+                            data.vulnerability.data.forEach(x => {
+                                lines.push(`### ${x.cve_id}`);
+                                lines.push(`* ${x.cve_description}`);
+                                lines.push(`* CVSSV2 Score: ${x.cvssv2_score}`);
+                                lines.push(`* CVSSV3 Score: ${x.cvssv3_score}`);
+                            });
+                        }
+
+                        lines.push(`*/\n`);
+                        const report = lines.join('\n');
+
+                        appendTextToEditor(report);
+                        pushPromptMessage("system", report);
+                    }).catch(error => {
+                        console.error(error);
+                        appendTextToEditor(`\n// Failed to query Criminal IP: ${error.message}`);
                     });
                 };
 
@@ -578,7 +650,8 @@
                         onSavePromptClick: savePromptMessages,
                         onLoadPromptClick: loadPromptMessages,
                         onQueryWhoisClick: queryWhois,
-                        onQueryDnsClick: queryDns
+                        onQueryDnsClick: queryDns,
+                        onQueryCitiClick: queryCiti
                     }),
                     _e('div', { id: 'container' },
                         _e(Editor, { editorRef }),


### PR DESCRIPTION
## Summary by Sourcery

Integrate Criminal IP lookup into the WelsonJS Editor by adding a new IP query tool, the necessary client-side UI, server-side proxy, and configuration entries; also improve existing network query formatting and API key error handling.

New Features:
- Add a Criminal IP (citi-query) button to the ribbon and implement client-side logic to fetch and format IP reports.
- Introduce a ResourceTools.CitiQuery server handler to proxy requests to the Criminal IP API.
- Expose new configuration keys (CitiApiKey and CitiApiPrefix) for Criminal IP integration.

Bug Fixes:
- Add checks and user alerts for missing Azure AI service API key before sending requests.

Enhancements:
- Prepend hostname labels to appended Whois and DNS query results.
- Wrap JSON results in XML within ResourceServer for uniform resource serving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "IP" button to the RibbonMenu, enabling users to query Criminal IP asset reports for a specified IP address directly from the editor.
  - The app now retrieves and displays detailed network port and vulnerability information for queried IPs, presenting results in a formatted report within the editor.

- **Bug Fixes**
  - Improved error handling for missing or empty API keys, alerting users and preventing failed network queries.

- **Chores**
  - Updated application settings and resources to support integration with the Criminal IP API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->