### PR TITLE
Fix #251 #246

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -297,11 +297,11 @@ var ChromeObject = function() {
 
             // set user agent
             if (this.userAgent != null) {
-                cmd.push("--user-agent=\"" + this.userAgent + "\"");
+                cmd.push("\"--user-agent=" + this.userAgent + "\"");
             }
 
             // set the URL
-            cmd.push((!this.isAppMode ? "\"" : "--app=\"") + url + "\"");
+            cmd.push((this.isAppMode ? "--app=\"" : "\"") + url + "\"");
 
             // build the command line
             console.log(cmd.join(" "));
@@ -313,7 +313,7 @@ var ChromeObject = function() {
             // release shell
             shell.release();
         } catch (e) {
-            console.error(e.message, ", Error in ChromeObject.open()");
+            console.error("Error opening a browser: " + e.message);
             sleep(300);
         }
 
@@ -326,7 +326,7 @@ var ChromeObject = function() {
         if (this.debuggingPort > 0) {
             try {
                 var responseText = HTTP.get("http://127.0.0.1:" + this.debuggingPort + "/json");
-                var pageList = JSON.parse(responseText);
+                pageList = JSON.parse(responseText);
                 
                 this.pageList = pageList;  // save the page list
             } catch (e) {
@@ -1245,11 +1245,11 @@ var ChromeObject = function() {
     // @deprecated
     this.setVendor = function(vendor) {
         this.setPublisherName(vendor);
-        console.warn("Deprecated: setVendor, Alternative: setPublisherName");
+        console.warn("Deprecated: Please use setPublisherName");
     };
 
     this.setPublisherName = function(publisherName) {
-        var publisherName = publisherName.toLowerCase();
+        publisherName = publisherName.toLowerCase();
 
         switch (publisherName) {
             case "msedge":

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -26,6 +26,7 @@ var ChromeObject = function() {
 
     this.profileName = "Default";
     this.userDataDir = null;
+    this.installedDir = "Chrome";
 
     // proxy
     this.isPreventProxy = false;
@@ -76,6 +77,8 @@ var ChromeObject = function() {
 
     this.setProfile = function(profileName, installedDir) {
         this.profileName = (profileName == "Default" ? "Chrome" : profileName);
+        this.workingDirectory = this.workingDirectory.replace(":installedDir", installedDir);
+        this.binPath = this.binPath.replace(":installedDir", installedDir);
         return this;
     };
 
@@ -156,11 +159,7 @@ var ChromeObject = function() {
         }
 
         var cmd = [
-            "cscript",
-            "app.js",
-            "shoutcut",
-            "chrome",
-            this.installedDir,
+            this.binPath
         ];
 
         // disable default browser check
@@ -189,7 +188,7 @@ var ChromeObject = function() {
         cmd.push("\"--user-data-dir=" + this.userDataDir + "\"");
         cmd.push("\"" + url + "\"");
 
-        SHELL.createShoutcut("Chrome (" + this.installedDir + ")", cmd.join(' '), SYS.getCurrentScriptDirectory());
+        SHELL.createShoutcut(this.publisherName + " (" + this.profileName + ")", cmd.join(' '), SYS.getCurrentScriptDirectory());
     };
 
     this.setInPrivate = function(flag) {
@@ -226,7 +225,7 @@ var ChromeObject = function() {
         if (!FILE.fileExists(this.binPath)) {
             this.workingDirectory = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Google\\:installedDir\\Application";
             this.binPath = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Google\\:installedDir\\Application\\chrome.exe";
-            this.setProfile(this.profileName);
+            this.setProfile(this.profileName, this.installedDir);
         }
 
         // find a executable file
@@ -1254,7 +1253,7 @@ var ChromeObject = function() {
 
             case "chrome":
                 this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application";
-                this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application\\chrome.exe";
+                this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\:installedDir\\Application\\chrome.exe";
                 break;
 
             case "chromium":

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -1250,32 +1250,31 @@ var ChromeObject = function() {
             case "msedge":
                 this.workingDirectory = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Microsoft\\Edge\\Application";
                 this.binPath = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Microsoft\\Edge\\Application\\msedge.exe";
-                this.setUserDataDir(null);
                 break;
 
             case "chrome":
                 this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application";
                 this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application\\chrome.exe";
-                this.setUserDataDir(null);
                 break;
 
             case "chromium":
                 this.workingDirectory = SYS.getEnvString("LOCALAPPDATA") + "\\Chromium\\Application";
                 this.binPath = SYS.getEnvString("LOCALAPPDATA") + "\\Chromium\\Application\\chrome.exe";
-                this.setUserDataDir(null);
                 break;
 
             case "opera":
                 this.workingDirectory = SYS.getEnvString("LOCALAPPDATA") + "\\Programs\\Opera";
                 this.binPath = SYS.getEnvString("LOCALAPPDATA") + "\\Programs\\Opera\\opera.exe";
-                this.setUserDataDir(null);
                 break;
                 
             case "whale":
                 this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Naver\\Naver Whale\\Application";
                 this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Naver\\Naver Whale\\Application\\whale.exe";
-                this.setUserDataDir(null);
                 break;
+        }
+        
+        if (!this.userDataDir) {
+            this.setUserDataDir(null);
         }
 
         return this;

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -1242,6 +1242,12 @@ var ChromeObject = function() {
         return this.getEvaluatedValue('(confirm("' + s + '") ? "true" : "false")');
     };
 
+    // @deprecated
+    this.setVendor = function(vendor) {
+        this.setPublisherName(vendor);
+        console.warn("Deprecated: setVendor, Alternative: setPublisherName");
+    };
+
     this.setPublisherName = function(publisherName) {
         var publisherName = publisherName.toLowerCase();
 

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -2,7 +2,7 @@
 // Chrome Web Browser Debugging Interface for WelsonJS framework
 // Namhyeon Go <abuse@catswords.net>
 // https://github.com/gnh1201/welsonjs
-
+// 
 var STD = require("lib/std");
 var RAND = require("lib/rand");
 var SHELL = require("lib/shell");
@@ -20,12 +20,10 @@ var pageEventId = 0;
 var ChromeObject = function() {
     STD.EventTarget.apply(this, arguments);  // Set event-attachable object
 
-    this.vendor = "Chrome";
-    this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Google\\:installedDir\\Application";
-    this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\:installedDir\\Application\\chrome.exe";
+    this.publisherName = "chrome";
+    this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application";
+    this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application\\chrome.exe";
 
-    //this.processID = 0;
-    this.installedDir = "Chrome";
     this.profileName = "Default";
     this.userDataDir = null;
 
@@ -78,10 +76,6 @@ var ChromeObject = function() {
 
     this.setProfile = function(profileName, installedDir) {
         this.profileName = (profileName == "Default" ? "Chrome" : profileName);
-        this.setInstalledDir(installedDir);
-        this.workingDirectory = this.workingDirectory.replace(":installedDir", this.installedDir);
-        this.binPath = this.binPath.replace(":installedDir", this.installedDir);
-        //this.binPath = this.binPath.replace(":installedDir", "Chrome");
         return this;
     };
 
@@ -91,7 +85,7 @@ var ChromeObject = function() {
             try {
                 return FILE.deleteFolder(FN);
             } catch (e) {
-                console.warn("Can not clear the session! Resaon: " + e.message);
+                console.warn("Can not clear the session! " + e.message);
                 console.warn("Retrying clear the profile...");
             }
         }
@@ -105,14 +99,7 @@ var ChromeObject = function() {
         if (dirname != null) {
             this.userDataDir = dirname;
         } else {
-            this.userDataDir = SHELL.getPathOfMyDocuments() + "\\UserData_Chrome_" + this.profileName;
-        }
-        return this;
-    };
-
-    this.setInstalledDir = function(dirname) {
-        if (dirname != null) {
-            this.installedDir = dirname;
+            this.userDataDir = SYS.getEnvString("APPDATA") + "\\WelsonJS\\" + this.publisherName + "_user_profile";
         }
         return this;
     };
@@ -165,13 +152,13 @@ var ChromeObject = function() {
 
     this.createShoutcut = function(url) {
         if (!this.userDataDir) {
-            this.userDataDir = SHELL.getPathOfMyDocuments() + "\\UserData_Chrome_" + this.profileName;
+            this.setUserDataDir(null);
         }
 
         var cmd = [
             "cscript",
             "app.js",
-            "shoutcut.legacy",
+            "shoutcut",
             "chrome",
             this.installedDir,
         ];
@@ -198,11 +185,11 @@ var ChromeObject = function() {
             cmd.push("--remote-debugging-port=" + this.debuggingPort);
         }
 
-        cmd.push("--profile-directory=\"" + this.profileName + "\"");
-        cmd.push("--user-data-dir=\"" + this.userDataDir + "\"");
+        cmd.push("\"--profile-directory=" + this.profileName + "\"");
+        cmd.push("\"--user-data-dir=" + this.userDataDir + "\"");
         cmd.push("\"" + url + "\"");
 
-        SHELL.createShoutcut("Chrome Prototype (" + this.installedDir + ")", cmd.join(' '), SYS.getCurrentScriptDirectory());
+        SHELL.createShoutcut("Chrome (" + this.installedDir + ")", cmd.join(' '), SYS.getCurrentScriptDirectory());
     };
 
     this.setInPrivate = function(flag) {
@@ -239,50 +226,19 @@ var ChromeObject = function() {
         if (!FILE.fileExists(this.binPath)) {
             this.workingDirectory = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Google\\:installedDir\\Application";
             this.binPath = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Google\\:installedDir\\Application\\chrome.exe";
-            this.setProfile(this.profileName, this.installedDir);
+            this.setProfile(this.profileName);
         }
 
-        // find profile
+        // find a executable file
         if (!FILE.fileExists(this.binPath)) {
-            console.error("ChromeObject.open() -> '" + this.profileName + "' profile does not exists. You have to create it.");
+            console.error("chrome.exe does not exists.");
             return this;
         }
-
-        // create shoutcut to desktop
-        if (this.debuggingPort == 0) {
-            this.createShoutcut();
-        }
-
-        /*
-        var process;
-        while (this.processID == 0) {
-            try {
-                if (!this.userDataDir) {
-                    this.userDataDir = SHELL.getPathOfMyDocuments() + "\\UserData_Chrome_" + this.profileName;
-                }
-                var shell = SHELL.create().setWorkingDirectory(this.workingDirectory);
-                var process = shell.createProcess([
-                    "\"" + this.binPath + "\"",
-                    "--profile-directory=\"" + this.profileName + "\"",
-                    "--proxy-server=\"socks5://127.0.0.1:" + this.proxyPort + "\"",
-                    "--user-data-dir=\"" + this.userDataDir + "\"",
-                    "\"" + url + "\""
-                ].join(" "));
-                sleep(1500);
-                this.processID = process.ProcessID;
-                sleep(1500);
-                shell.release();
-            } catch (e) {
-                console.error("ChromeObject.open() ->", e.message);
-                sleep(1500);
-            }
-        }
-        */
-
+        
         try {
             // get user data directory
             if (!this.userDataDir) {
-                this.userDataDir = SHELL.getPathOfMyDocuments() + "\\UserData_Chrome_" + this.profileName;
+                this.setUserDataDir(null);
             }
 
             // connect to shell
@@ -321,7 +277,7 @@ var ChromeObject = function() {
             //cmd.push("--restore-last-session");
 
             // set profile directory
-            cmd.push("--profile-directory=\"" + this.profileName + "\"");
+            cmd.push("\"--profile-directory=" + this.profileName + "\"");
 
             // set proxy configuration
             if (this.proxy != null && this.isPreventProxy != true) {
@@ -333,7 +289,7 @@ var ChromeObject = function() {
             }
 
             // set user data directory
-            cmd.push("--user-data-dir=\"" + this.userDataDir + "\"");
+            cmd.push("\"--user-data-dir=" + this.userDataDir + "\"");
 
             // choice user agent
             if (this.userAgent == null && this.userAgents.length > 0) {
@@ -346,11 +302,7 @@ var ChromeObject = function() {
             }
 
             // set the URL
-            if (!this.isAppMode) {
-                cmd.push("\"" + url + "\"");
-            } else {
-                cmd.push("--app=\"" + url + "\"");
-            }
+            cmd.push((!this.isAppMode ? "\"" : "--app=\"") + url + "\"");
 
             // build the command line
             console.log(cmd.join(" "));
@@ -362,7 +314,7 @@ var ChromeObject = function() {
             // release shell
             shell.release();
         } catch (e) {
-            console.error("ChromeObject.open() -> ", e.message);
+            console.error(e.message, ", Error in ChromeObject.open()");
             sleep(300);
         }
 
@@ -374,28 +326,18 @@ var ChromeObject = function() {
 
         if (this.debuggingPort > 0) {
             try {
-                //var responseText = HTTP.get("http://127.0.0.1:" + this.debuggingPort + "/json");
-                //console.log(responseText);
-                //pageList = JSON.parse(responseText);
-
-                var pageList = HTTP.create("CURL")
-                    .setDataType("json")
-                    .open("GET", "http://127.0.0.1:" + this.debuggingPort + "/json")
-                    .send()
-                    .responseBody
-                ;
-
-                this.pageList = pageList;
-                return pageList;
+                var responseText = HTTP.get("http://127.0.0.1:" + this.debuggingPort + "/json");
+                var pageList = JSON.parse(responseText);
+                
+                this.pageList = pageList;  // save the page list
             } catch (e) {
                 console.error("ChromeObject.getPageList() ->", e.message);
-                //return this.getPageList();    // 무한 루프 문제로 주석처리
-                return pageList;   // 바로 넘김
             }
         } else {
             console.error("Remote debugging unavailable");
-            return pageList;
         }
+        
+        return pageList;
     };
 
     this.getPageById = function(id) {
@@ -1301,28 +1243,38 @@ var ChromeObject = function() {
         return this.getEvaluatedValue('(confirm("' + s + '") ? "true" : "false")');
     };
 
-    this.setVendor = function(vendor) {
-        var vendor = vendor.toLowerCase();
+    this.setPublisherName = function(publisherName) {
+        var publisherName = publisherName.toLowerCase();
 
-        switch (vendor) {
+        switch (publisherName) {
             case "msedge":
                 this.workingDirectory = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Microsoft\\Edge\\Application";
                 this.binPath = SYS.getEnvString("PROGRAMFILES(X86)") + "\\Microsoft\\Edge\\Application\\msedge.exe";
+                this.setUserDataDir(null);
                 break;
 
             case "chrome":
                 this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application";
-                this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\:installedDir\\Application\\chrome.exe";
+                this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Google\\Chrome\\Application\\chrome.exe";
+                this.setUserDataDir(null);
                 break;
 
             case "chromium":
                 this.workingDirectory = SYS.getEnvString("LOCALAPPDATA") + "\\Chromium\\Application";
                 this.binPath = SYS.getEnvString("LOCALAPPDATA") + "\\Chromium\\Application\\chrome.exe";
+                this.setUserDataDir(null);
                 break;
 
             case "opera":
                 this.workingDirectory = SYS.getEnvString("LOCALAPPDATA") + "\\Programs\\Opera";
                 this.binPath = SYS.getEnvString("LOCALAPPDATA") + "\\Programs\\Opera\\opera.exe";
+                this.setUserDataDir(null);
+                break;
+                
+            case "whale":
+                this.workingDirectory = SYS.getEnvString("PROGRAMFILES") + "\\Naver\\Naver Whale\\Application";
+                this.binPath = SYS.getEnvString("PROGRAMFILES") + "\\Naver\\Naver Whale\\Application\\whale.exe";
+                this.setUserDataDir(null);
                 break;
         }
 
@@ -1448,7 +1400,7 @@ exports.startDebugInPrivate = function(url, proxy, profileName, debuggingPort, i
     ;
 };
 
-exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.4.16";
+exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.4.17";
 exports.AUTHOR = "abuse@catswords.net";
 exports.global = global;
 exports.require = global.require;


### PR DESCRIPTION
Fix #251 #246

## Summary by Sourcery

Update ChromeObject to use publisherName, streamline path and command handling, improve session and page list operations, and add Whale browser support

New Features:
- Add support for Naver Whale browser in setPublisherName

Bug Fixes:
- Fix default user data directory path to use APPDATA and publisherName
- Correct warning and error messages in session clearing and open methods

Enhancements:
- Rename vendor property to publisherName throughout
- Consolidate userDataDir initialization via setUserDataDir
- Simplify command-line argument quoting and construction in createShoutcut and open methods
- Switch getPageList implementation to use HTTP.get and JSON.parse

Chores:
- Bump version to 0.4.17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "whale" browser.
- **Improvements**
  - Improved naming consistency by updating references from "vendor" to "publisherName".
  - Enhanced default user data directory handling for better compatibility.
  - Refined command line argument formatting for launching browsers.
  - Simplified retrieval of page lists for improved reliability.
- **Other**
  - Updated version information to 0.4.17.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->