### PR TITLE
[lib/chrome] Update the `--disabled-features` flag

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -56,6 +56,7 @@ var ChromeObject = function() {
     this.pageList = [];
     this.title = "";
     this.frameIndex = -1;
+    this.disableFeatures = ["ShowBookmarksBar", "Translate"];
 
     this.isPreventEvaluate = false;
     this.isAppMode = false;
@@ -318,6 +319,9 @@ var ChromeObject = function() {
             if (this.userAgent != null) {
                 cmd.push("\"--user-agent=" + this.userAgent + "\"");
             }
+            
+            // disable an unwanted features
+            cmd.push("--disable-features=" + this.disableFeatures.join(','));
 
             // set the URL
             cmd.push((this.isAppMode ? "--app=\"" : "\"") + url + "\"");
@@ -1382,6 +1386,31 @@ var ChromeObject = function() {
     this.requestFullscreen = function() {
         this.evaluate('document.documentElement.requestFullscreen();');
     };
+    
+    this.getDisableFeatureIndex = function(feature) {
+        return this.disableFeatures.indexOf(feature);
+    };
+
+    this.isFeatureDisabled = function(feature) {
+        return this.getDisableFeatureIndex(feature) > -1;
+    };
+    
+    this.addDisableFeature = function(feature) {
+        if (!this.isFeatureDisabled(feature)) {
+            this.disableFeatures.push(feature);
+        }
+        
+        return this;
+    };
+
+    this.removeDisableFeature = function(feature) {
+        var index = this.getDisableFeatureIndex(feature);
+        if (index > -1) {
+            this.disableFeatures.splice(index, 1);
+        }
+        
+        return this;
+    };
 
     this.create();
 };
@@ -1453,7 +1482,7 @@ exports.startDebugInPrivate = function(url, proxy, profileName, debuggingPort, i
 
 exports.publisherName = publisherName;
 
-exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.4.22";
+exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.4.23";
 exports.AUTHOR = "abuse@catswords.net";
 exports.global = global;
 exports.require = global.require;

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -320,8 +320,10 @@ var ChromeObject = function() {
                 cmd.push("\"--user-agent=" + this.userAgent + "\"");
             }
             
-            // disable an unwanted features
-            cmd.push("--disable-features=" + this.disableFeatures.join(','));
+            // disable unwanted features
+            if (this.disableFeatures.length > 0) {
+                cmd.push("\"--disable-features=" + this.disableFeatures.join(',') + "\"");
+            }
 
             // set the URL
             cmd.push((this.isAppMode ? "--app=\"" : "\"") + url + "\"");


### PR DESCRIPTION
[lib/chrome] Update the `--disabled-features` flag

## Summary by Sourcery

Introduce a configurable disable-features mechanism in ChromeObject, allowing default and dynamic control over which Chrome features are disabled.

New Features:
- Add API methods (getDisableFeatureIndex, isFeatureDisabled, addDisableFeature, removeDisableFeature) to manage Chrome's disabled features list

Enhancements:
- Initialize the disableFeatures list with ShowBookmarksBar and Translate by default
- Include the --disable-features flag in Chrome launch arguments based on the disableFeatures array
- Bump VERSIONINFO to 0.4.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to manage disabled Chrome features, including viewing, adding, and removing features from the disabled list.
- **Chores**
	- Updated version information to 0.4.23.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->