### PR TITLE
Replace the default SERP provider to SerpApi - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ WelsonJS = ***W***indows + ***El***ectr***on***-like + ***Javascript(JS)*** + :h
 
 ## Sponsors
 * :octocat: [GitHub Sponsors](https://github.com/sponsors/gnh1201), :coffee: [Buy me a coffee](https://buymeacoffee.com/catswords)
-* <img src="https://ics.catswords.net/serpapi_logo_32.png" height="32" alt=""/> [SerpApi](https://serpapi.com/?utm_source=welsonjs) - Scrape search engines results with simple API.
+* <img src="https://ics.catswords.net/serpapi_logo_32.png" height="32" alt=""/> [SerpApi](https://serpapi.com/?utm_source=welsonjs): Search API - Scrape search engines results with simple API.
 * <img src="https://ics.catswords.net/logo_oss.gif" height="32" alt=""/> [Open SW Portal](https://oss.kr), NIPA National IT Industry Promotion Agency<sup>(정보통신산업진흥원)</sup>
 * <img src="https://ics.catswords.net/signpath_logo.png" height="32" alt=""/> Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org/)
 * <img src="https://ics.catswords.net/f1security_logo.png" height="32" alt=""/> [F1Security<sup>(에프원시큐리티)</sup>](https://f1security.co.kr/) provides [industry-leading](https://www.ksecurity.or.kr/kisis/subIndex/469.do) web security services.


### PR DESCRIPTION
Replace the default SERP provider to SerpApi - Update README.md

## Summary by Sourcery

Switch the default SERP provider to SerpApi and update the README to reflect the new provider and description format.

Enhancements:
- Replace default SERP provider with SerpApi

Documentation:
- Update README sponsor entry for SerpApi with new description format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description for the SerpApi sponsor in the Sponsors section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->