### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,10 @@ The WelsonJS framework suggests the following application release methods:
 * :heart: Artwork (Logo image): [@druidesse](https://github.com/druidesse)
 * :heart: Artwork (Cover image): [@_bag0@x.com](https://x.com/_bag0)
 * :heart: Special Contributors: [@hcho3](https://github.com/hcho3), :octocat: [GitHub Sponsors](https://github.com/sponsors/gnh1201)
-* :sunglasses: Heavy-industry specialized CSP(Cloud Service Provider) in Republic of Korea - Use case establishment
-* :sunglasses: Live-commerce specialized online advertisement companies in Republic of Korea - Use case establishment
-* :sunglasses: Information security companies in Republic of Korea - Use case establishment
+* :sunglasses: Heavy-industry specialized CSP(Cloud Service Provider) in Republic of Korea - Use case development
+* :sunglasses: Live-commerce specialized online advertisement companies in Republic of Korea - Use case development
+* :sunglasses: Information security companies in Republic of Korea - Use case development
+* :sunglasses: Travel planning(e.g., Airlines, Hotels, Ticketing) related companies - Use case development
 * :eyes: [Facebook Group "Javascript Programming"(javascript4u)](https://www.facebook.com/javascript4u/posts/build-a-windows-desktop-apps-with-javascript-html-and-cssmorioh-javascript-html-/1484014618472735/)
 * :eyes: [morioh.com](https://morioh.com/a/23c427a82bf1/build-a-windows-desktop-apps-with-javascript-html-and-css)
 * :eyes: CSDN


### PR DESCRIPTION
Update README.md

## Summary by Sourcery

Update use case descriptions in README and add new travel planning use case

Documentation:
- Change use case wording from ‘establishment’ to ‘development’ for heavy-industry CSP, live-commerce advertisers, and information security companies
- Add new travel planning (airlines, hotels, ticketing) companies use case bullet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Thanks to" section in the README to clarify existing use case contributions and added recognition for travel planning-related companies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->