### PR TITLE
Add resource server autostart and Chromium config options

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/MainForm.cs
@@ -17,7 +17,6 @@ namespace WelsonJS.Launcher
     public partial class MainForm : Form
     {
         private const string _entryFileName = "bootstrap.bat";
-
         private readonly string _dateTimeFormat;
 
         private string _workingDirectory;
@@ -26,18 +25,28 @@ namespace WelsonJS.Launcher
 
         public MainForm()
         {
+            // set the datetime format
             _dateTimeFormat = Program.GetAppConfig("DateTimeFormat");
 
+            // initialize UI
             InitializeComponent();
 
+            // Check the user is an Administator
             if (IsInAdministrator())
             {
                 Text += " (Administrator)";
             }
 
+            // tray icon
             notifyIcon1.DoubleClick += OnShow;
             openLauncherToolStripMenuItem.Click += OnShow;
             exitToolStripMenuItem.Click += OnExit;
+
+            // Autostart the resource server
+            if (Program.GetAppConfig("ResourceServerAutoStart").ToLower() == "true")
+            {
+                RunResourceServer();
+            }
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
@@ -120,12 +129,12 @@ namespace WelsonJS.Launcher
                     string filePath = openFileDialog.FileName;
 
                     DisableUI();
-                    Task.Run(() => ExtractAndRun(filePath));
+                    Task.Run(() => RunAppPackageFile(filePath));
                 }
             }
         }
 
-        private void ExtractAndRun(string filePath)
+        private void RunAppPackageFile(string filePath)
         {
             _instanceId = Guid.NewGuid().ToString();
             _workingDirectory = Program.GetWorkingDirectory(_instanceId);
@@ -158,6 +167,19 @@ namespace WelsonJS.Launcher
 
             // Enable UI
             SafeInvoke(() => EnableUI());
+        }
+
+        private bool RunResourceServer()
+        {
+            Program.InitResourceServer();
+
+            if (!Program._ResourceServer.IsRunning())
+            {
+                Program._ResourceServer.Start(false);
+                startCodeEditorToolStripMenuItem.Text = "Open the code editor...";
+            }
+
+            return Program._ResourceServer.IsRunning();
         }
 
         private void RecordFirstDeployTime(string directory, string instanceId)
@@ -263,14 +285,7 @@ namespace WelsonJS.Launcher
 
         private void startCodeEditorToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Program.StartResourceServer();
-
-            if (!Program._ResourceServer.IsRunning())
-            {
-                Program._ResourceServer.Start();
-                ((ToolStripMenuItem)sender).Text = "Open the code editor...";
-            }
-            else
+            if (RunResourceServer())
             {
                 Program.OpenWebBrowser(Program._ResourceServer.GetPrefix());
             }

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Program.cs
@@ -146,7 +146,7 @@ namespace WelsonJS.Launcher
             return workingDirectory;
         }
 
-        public static void StartResourceServer()
+        public static void InitResourceServer()
         {
             lock(typeof(Program))
             {
@@ -159,7 +159,7 @@ namespace WelsonJS.Launcher
         public static void OpenWebBrowser(string url)
         {
             Uri resourceServerUri = new Uri(GetAppConfig("ResourceServerPrefix"));
-            Uri devToolsUri = new Uri(GetAppConfig("DevToolsPrefix"));
+            Uri devToolsUri = new Uri(GetAppConfig("ChromiumDevToolsPrefix"));
 
             string userDataDir = Path.Combine(GetAppDataPath(), "EdgeUserProfile");
             string remoteAllowOrigins = $"{resourceServerUri.Scheme}://{resourceServerUri.Host}:{resourceServerUri.Port}";
@@ -173,7 +173,7 @@ namespace WelsonJS.Launcher
 
             Process.Start(new ProcessStartInfo
             {
-                FileName = "msedge.exe",
+                FileName = Program.GetAppConfig("ChromiumFileName"),
                 Arguments = string.Join(" ", arguments),
                 UseShellExecute = true
             });

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -106,6 +106,24 @@ namespace WelsonJS.Launcher.Properties {
         }
         
         /// <summary>
+        ///   http://localhost:9222/과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string ChromiumDevToolsPrefix {
+            get {
+                return ResourceManager.GetString("ChromiumDevToolsPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   msedge.exe과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string ChromiumFileName {
+            get {
+                return ResourceManager.GetString("ChromiumFileName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
         internal static string CitiApiKey {
@@ -138,15 +156,6 @@ namespace WelsonJS.Launcher.Properties {
         internal static string DateTimeFormat {
             get {
                 return ResourceManager.GetString("DateTimeFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   http://localhost:9222/과(와) 유사한 지역화된 문자열을 찾습니다.
-        /// </summary>
-        internal static string DevToolsPrefix {
-            get {
-                return ResourceManager.GetString("DevToolsPrefix", resourceCulture);
             }
         }
         
@@ -274,6 +283,15 @@ namespace WelsonJS.Launcher.Properties {
         internal static string RepositoryUrl {
             get {
                 return ResourceManager.GetString("RepositoryUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   true과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string ResourceServerAutoStart {
+            get {
+                return ResourceManager.GetString("ResourceServerAutoStart", resourceCulture);
             }
         }
         

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
@@ -157,7 +157,7 @@
   <data name="ResourceServerPrefix" xml:space="preserve">
     <value>http://localhost:3000/</value>
   </data>
-  <data name="DevToolsPrefix" xml:space="preserve">
+  <data name="ChromiumDevToolsPrefix" xml:space="preserve">
     <value>http://localhost:9222/</value>
   </data>
   <data name="AzureAiServiceApiKey" xml:space="preserve">
@@ -198,5 +198,11 @@
   </data>
   <data name="DateTimeFormat" xml:space="preserve">
     <value>yyyy-MM-dd HH:mm:ss</value>
+  </data>
+  <data name="ResourceServerAutoStart" xml:space="preserve">
+    <value>true</value>
+  </data>
+  <data name="ChromiumFileName" xml:space="preserve">
+    <value>msedge.exe</value>
   </data>
 </root>

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
@@ -30,6 +30,7 @@ namespace WelsonJS.Launcher
         private string _prefix;
         private string _resourceName;
         private List<IResourceTool> _tools = new List<IResourceTool>();
+
         private static readonly HttpClient _httpClient = new HttpClient();
         private static readonly string _defaultMimeType = "application/octet-stream";
         private static BlobConfig _blobConfig;
@@ -66,7 +67,7 @@ namespace WelsonJS.Launcher
             return _prefix;
         }
 
-        public void Start()
+        public void Start(bool IsOpenWebBrowser = true)
         {
             if (_isRunning) return;
 
@@ -75,7 +76,10 @@ namespace WelsonJS.Launcher
             _listener.Start();
 
             // Open the web browser
-            Program.OpenWebBrowser(_prefix);
+            if (IsOpenWebBrowser)
+            {
+                Program.OpenWebBrowser(_prefix);
+            }
 
             // Run a task with cancellation token
             _serverTask = Task.Run(() => ListenLoop(_cts.Token));

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/app.config
@@ -2,9 +2,11 @@
 <configuration>
   <appSettings>
     <add key="ResourceServerPrefix" value="http://localhost:3000/"/>
+    <add key="ResourceServerAutoStart" value="true"/>
     <add key="RepositoryUrl" value="https://github.com/gnh1201/welsonjs"/>
     <add key="CopilotUrl" value="https://copilot.microsoft.com/"/>
-    <add key="DevToolsPrefix" value="http://localhost:9222/"/>
+    <add key="ChromiumDevToolsPrefix" value="http://localhost:9222/"/>
+    <add key="ChromiumFileName" value="msedge.exe"/>
     <add key="AzureAiServicePrefix" value="https://ai-catswords656881030318.services.ai.azure.com/"/>
     <add key="AzureAiServiceApiKey" value=""/>
     <add key="AzureAiServiceApiVersion" value="2024-05-01-preview"/>


### PR DESCRIPTION
Introduces ResourceServerAutoStart and ChromiumFileName/ChromiumDevToolsPrefix settings to app.config and resources. Refactors resource server startup logic to support autostart and configurable browser launch. Cleans up related code in MainForm and Program for improved flexibility and maintainability.