### PR TITLE
Switch Chrome RPC from WebSocket to HTTP gateway

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -5,13 +5,15 @@
 // 
 // Chrome Web Browser Debugging Interface for WelsonJS framework
 // 
+// To use this feature, a gateway that converts between stateless HTTP and WebSocket protocols is required.
+// Run the WelsonJS Launcher, which supports this conversion, or use another compatible tool.
+// 
 var STD = require("lib/std");
 var RAND = require("lib/rand");
 var SHELL = require("lib/shell");
 var SYS = require("lib/system");
 var FILE = require("lib/file");
 var HTTP = require("lib/http");
-var Websocket = require("lib/websocket");
 var AutoIt = require("lib/autoit");
 var Toolkit = require("lib/toolkit");
 var ExtraMath = require("lib/extramath");
@@ -424,13 +426,27 @@ var ChromeObject = function() {
 
         try {
             if (this.pageId != "") {
-                result = this.ws.send("ws://127.0.0.1:" + this.debuggingPort + "/devtools/page/" + this.pageId, JSON.stringify({
-                    "id": pageEventId.get(),
-                    "method": method,
-                    "params": params
-                }));
+                var url = "http://localhost:3000/devtools/page/" + this.pageId + "?port=" + this.debuggingPort;
+                try {
+                    result = HTTP.create()
+                        .setContentType("application/json")
+                        .setDataType("json")
+                        .open("POST", url)
+                        .setRequestBody({
+                            "id": pageEventId,
+                            "method": method,
+                            "params": params
+                        })
+                        .send()
+                        .responseBody
+                    ;
+                } catch (e) {
+                    console.warn(e.message);
+                    result = {};
+                }
+                
                 pageEventId.set(pageEventId.get() + 1);
-                console.log("ChromeObject().sendPageRPC() -> Sent");
+                console.log("Sent the RPC message");
             } else {
                 this.setPageId(null);
                 if (this.pageId != "") {
@@ -478,15 +494,8 @@ var ChromeObject = function() {
 
     this.getEvaluatedValue = function(expression) {
         try {
-            var responseText = this.evaluate(expression);
-            console.log(responseText);
-
-            var result = JSON.parse(responseText).result.result.value;
-            if (typeof(result) !== "undefined" && result != null) {
-                return result;
-            } else {
-                return "";
-            }
+            var response = this.evaluate(expression);
+            return response.result.result.value;
         } catch (e) {
             console.error("ChromeObject.getEvaluatedValue() ->", e.message);
             return "";
@@ -1484,7 +1493,7 @@ exports.startDebugInPrivate = function(url, proxy, profileName, debuggingPort, i
 
 exports.publisherName = publisherName;
 
-exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.4.23";
+exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.5";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;


### PR DESCRIPTION
Replaces WebSocket-based RPC communication with HTTP POST requests to a gateway for Chrome debugging. Updates documentation to clarify the need for a protocol conversion gateway and refactors related methods for compatibility. Bumps version to 0.5.