### PR TITLE
Improve error handling in sendPageRPC and getEvaluatedValue

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -422,13 +422,13 @@ var ChromeObject = function() {
     };
 
     this.sendPageRPC = function(method, params) {
-        var result = null;
+        var response = null;
 
         try {
             if (this.pageId != "") {
                 var url = "http://localhost:3000/devtools/page/" + this.pageId + "?port=" + this.debuggingPort;
                 try {
-                    result = HTTP.create()
+                    response = HTTP.create()
                         .setContentType("application/json")
                         .setDataType("json")
                         .open("POST", url)
@@ -440,9 +440,18 @@ var ChromeObject = function() {
                         .send()
                         .responseBody
                     ;
+                    
+                    // response if error
+                    if ("result" in response) {
+                        (function(r) {
+                            if ("subtype" in r && r.subtype == "error") {
+                                console.warn("[WebBrowser]", r.description);
+                            }
+                        })(response.result.result);
+                    }
                 } catch (e) {
                     console.warn(e.message);
-                    result = {};
+                    response = {};
                 }
                 
                 pageEventId.set(pageEventId.get() + 1);
@@ -450,7 +459,7 @@ var ChromeObject = function() {
             } else {
                 this.setPageId(null);
                 if (this.pageId != "") {
-                    result = this.sendPageRPC(method, params);
+                    response = this.sendPageRPC(method, params);
                 } else {
                     console.error("Page not found");
                 }
@@ -459,7 +468,7 @@ var ChromeObject = function() {
             console.log("ChromeObject.sendPageRPC() ->", e.message);
         }
 
-        return result;
+        return response;
     };
 
     this.navigate = function(url) {
@@ -495,7 +504,9 @@ var ChromeObject = function() {
     this.getEvaluatedValue = function(expression) {
         try {
             var response = this.evaluate(expression);
-            return response.result.result.value;
+            return (function(r) {
+                return ("value" in r ? r.value : "");
+            })(response.result.result);
         } catch (e) {
             console.error("ChromeObject.getEvaluatedValue() ->", e.message);
             return "";
@@ -1493,7 +1504,7 @@ exports.startDebugInPrivate = function(url, proxy, profileName, debuggingPort, i
 
 exports.publisherName = publisherName;
 
-exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.5";
+exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.5.1";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -445,13 +445,16 @@ var ChromeObject = function() {
                     if ("result" in response) {
                         (function(r) {
                             if ("subtype" in r && r.subtype == "error") {
-                                console.warn("[WebBrowser]", r.description);
+                                console.warn(r.description);
                             }
                         })(response.result.result);
                     }
                 } catch (e) {
                     console.warn(e.message);
-                    response = {};
+                    response = {
+                        error: true,
+                        message: e && e.message ? e.message : "Request failed"
+                    };
                 }
                 
                 pageEventId.set(pageEventId.get() + 1);
@@ -1504,7 +1507,7 @@ exports.startDebugInPrivate = function(url, proxy, profileName, debuggingPort, i
 
 exports.publisherName = publisherName;
 
-exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.5.1";
+exports.VERSIONINFO = "Chrome Web Browser Debugging Interface (chrome.js) version 0.5.2";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;


### PR DESCRIPTION
Refactored sendPageRPC to better handle error responses and log error descriptions from the response object. Updated getEvaluatedValue to safely access the evaluated value, returning an empty string if not present. Bumped VERSIONINFO to 0.5.1.

## Summary by Sourcery

Improve error handling in sendPageRPC and safe value extraction in getEvaluatedValue, and bump version to 0.5.1

Enhancements:
- Log error descriptions from sendPageRPC responses with subtype "error"
- Refactor sendPageRPC to use and return a single response object consistently
- Update getEvaluatedValue to return an empty string when the evaluated value is absent

Chores:
- Bump VERSIONINFO to 0.5.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for responses, providing clearer warnings when errors are detected.
  * Enhanced value extraction to prevent potential issues when expected data is missing.

* **Chores**
  * Updated version information to 0.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->