### PR TITLE
Improve logging and async handling in ResourceServer

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/TraceLogger.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/TraceLogger.cs
@@ -12,6 +12,17 @@ namespace WelsonJS.Launcher
 {
     public class TraceLogger : ICompatibleLogger
     {
+        private static readonly string _logFileName;
+
+        static TraceLogger()
+        {
+            _logFileName = typeof(TraceLogger).Namespace + ".log";
+
+            var textWriterTraceListener = new TextWriterTraceListener(_logFileName);
+            Trace.Listeners.Add(textWriterTraceListener);
+            Trace.AutoFlush = true;
+        }
+
         public void Info(string message) => Trace.TraceInformation(message);
         public void Warn(string message) => Trace.TraceWarning(message);
         public void Error(string message) => Trace.TraceError(message);


### PR DESCRIPTION
ResourceServer now defaults to using TraceLogger if no logger is provided and properly awaits FetchBlobConfig. FetchBlobConfig is refactored to return a Task and handle missing configuration more gracefully. TraceLogger now writes logs to a file named after its namespace and sets up a TextWriterTraceListener for persistent logging.