### PR TITLE
Add abnormal case check to clusteredCellsDensity

### DIFF
--- a/lib/extramath.js
+++ b/lib/extramath.js
@@ -89,6 +89,14 @@ function clusteredCellsDensity(numbers, size, minDensity) {
         coords.push({ x: idx % size, y: Math.floor(idx / size) });
     }
 
+    // --- Additional rule: if more than 1/3 of the entire grid is selected,
+    // treat it as an abnormal case and return false immediately.
+    var globalRatio = coords.length / (size * size);
+    if (globalRatio > (1/3)) {
+        return false;
+    }
+
+    // --- Normal density calculation based on bounding box ---
     var xs = coords.map(function (c) { return c.x; });
     var ys = coords.map(function (c) { return c.y; });
 
@@ -135,7 +143,7 @@ exports.cartesianProduct = cartesianProduct;
 exports.clusteredCellsDensity = clusteredCellsDensity;
 exports.estimateTileStartPosition = estimateTileStartPosition;
 
-exports.VERSIONINFO = "ExtraMath module (extramath.js) version 1.0.3";
+exports.VERSIONINFO = "ExtraMath module (extramath.js) version 1.0.4";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;


### PR DESCRIPTION
Returns false if more than one third of the grid is selected, treating it as an abnormal case. Also updates VERSIONINFO to 1.0.4.