### PR TITLE
Rename CitiQuery to IpQuery and update API references

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -133,29 +133,29 @@ namespace WelsonJS.Launcher.Properties {
         }
         
         /// <summary>
+        ///   https://copilot.microsoft.com/과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string CopilotUrl {
+            get {
+                return ResourceManager.GetString("CopilotUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
-        internal static string CitiApiKey {
+        internal static string CriminalIpApiKey {
             get {
-                return ResourceManager.GetString("CitiApiKey", resourceCulture);
+                return ResourceManager.GetString("CriminalIpApiKey", resourceCulture);
             }
         }
         
         /// <summary>
         ///   https://api.criminalip.io/v1/과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
-        internal static string CitiApiPrefix {
+        internal static string CriminalIpApiPrefix {
             get {
-                return ResourceManager.GetString("CitiApiPrefix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   https://copilot.microsoft.com/과(와) 유사한 지역화된 문자열을 찾습니다.
-        /// </summary>
-        internal static string CopilotUrl {
-            get {
-                return ResourceManager.GetString("CopilotUrl", resourceCulture);
+                return ResourceManager.GetString("CriminalIpApiPrefix", resourceCulture);
             }
         }
         

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/Properties/Resources.resx
@@ -190,10 +190,10 @@
   <data name="HttpClientTimeout" xml:space="preserve">
     <value>90</value>
   </data>
-  <data name="CitiApiKey" xml:space="preserve">
+  <data name="CriminalIpApiKey" xml:space="preserve">
     <value />
   </data>
-  <data name="CitiApiPrefix" xml:space="preserve">
+  <data name="CriminalIpApiPrefix" xml:space="preserve">
     <value>https://api.criminalip.io/v1/</value>
   </data>
   <data name="DateTimeFormat" xml:space="preserve">

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceServer.cs
@@ -64,7 +64,7 @@ namespace WelsonJS.Launcher
             _tools.Add(new ResourceTools.Settings(this, _httpClient));
             _tools.Add(new ResourceTools.ChromiumDevTools(this, _httpClient));
             _tools.Add(new ResourceTools.DnsQuery(this, _httpClient));
-            _tools.Add(new ResourceTools.CitiQuery(this, _httpClient));
+            _tools.Add(new ResourceTools.IpQuery(this, _httpClient));
             _tools.Add(new ResourceTools.TwoFactorAuth(this, _httpClient));
             _tools.Add(new ResourceTools.Whois(this, _httpClient));
 

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceTools/IpQuery.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/ResourceTools/IpQuery.cs
@@ -10,13 +10,13 @@ using System.Threading.Tasks;
 
 namespace WelsonJS.Launcher.ResourceTools
 {
-    public class CitiQuery : IResourceTool
+    public class IpQuery : IResourceTool
     {
         private readonly ResourceServer Server;
         private readonly HttpClient _httpClient;
-        private const string Prefix = "citi-query/";
+        private const string Prefix = "ip-query/";
 
-        public CitiQuery(ResourceServer server, HttpClient httpClient)
+        public IpQuery(ResourceServer server, HttpClient httpClient)
         {
             Server = server;
             _httpClient = httpClient;
@@ -32,7 +32,7 @@ namespace WelsonJS.Launcher.ResourceTools
             try
             {
                 string target = path.Substring(Prefix.Length).Trim();
-                string apiKey = Program.GetAppConfig("CitiApiKey");
+                string apiKey = Program.GetAppConfig("CriminalIpApiKey");
                 if (string.IsNullOrEmpty(apiKey))
                 {
                     Server.ServeResource(context, "<error>Missing API key<error>", "application/xml", 500);
@@ -40,7 +40,7 @@ namespace WelsonJS.Launcher.ResourceTools
                 }
 
                 string encoded = Uri.EscapeDataString(target);
-                string apiPrefix = Program.GetAppConfig("CitiApiPrefix");
+                string apiPrefix = Program.GetAppConfig("CriminalIpApiPrefix");
                 string url = $"{apiPrefix}asset/ip/report?ip={encoded}&full=true";
 
                 var request = new HttpRequestMessage(HttpMethod.Get, url);

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/WelsonJS.Launcher.csproj
@@ -88,7 +88,7 @@
   <ItemGroup>
     <Compile Include="ICompatibleLogger.cs" />
     <Compile Include="IResourceTool.cs" />
-    <Compile Include="ResourceTools\CitiQuery.cs" />
+    <Compile Include="ResourceTools\IpQuery.cs" />
     <Compile Include="ResourceTools\Settings.cs" />
     <Compile Include="ResourceTools\Completion.cs" />
     <Compile Include="ResourceTools\ChromiumDevTools.cs" />

--- a/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/editor.html
@@ -130,7 +130,7 @@
             function RibbonMenu({
                 onOpenFileClick, onSaveFileClick, onCopliotClick, onAzureAiClick,
                 onSavePromptClick, onLoadPromptClick, onQueryWhoisClick, onQueryDnsClick,
-                onQueryCitiClick
+                onQueryIpClick
             }) {
                 const fileButtons = [
                     {
@@ -157,7 +157,7 @@
                 const networkToolsButtons = [
                     { id: 'btnWhois', icon: 'mif-earth', caption: 'Whois', onClick: onQueryWhoisClick },
                     { id: 'btnQueryDns', icon: 'mif-earth', caption: 'DNS', onClick: onQueryDnsClick },
-                    { id: 'btnQueryCiti', icon: 'mif-user-secret', caption: 'IP', onClick: onQueryCitiClick }
+                    { id: 'btnQueryIp', icon: 'mif-user-secret', caption: 'IP', onClick: onQueryIpClick }
                 ];
 
                 return _e(
@@ -583,23 +583,23 @@
                     });
                 };
 
-                const queryCiti = () => {
+                const queryIp = () => {
                     const hostname = prompt("Enter IP address:", '');
                     if (!hostname || hostname.trim() === '') {
                         appendTextToEditor("\n// IP address is required.");
                         return;
                     }
 
-                    const apiKey = settingsRef.current.CitiApiKey;
+                    const apiKey = settingsRef.current.CriminalIpApiKey;
                     if (!apiKey || apiKey.trim() === '') {
                         appendTextToEditor("\n// Criminal IP API key is not set.");
                         return;
                     }
 
-                    const apiPrefix = settingsRef.current.CitiApiPrefix;
+                    const apiPrefix = settingsRef.current.CriminalIpApiPrefix;
                     const ip = encodeURIComponent(hostname.trim());
 
-                    axios.get(`/citi-query/${hostname}`).then(response => {
+                    axios.get(`/ip-query/${hostname}`).then(response => {
                         if (!response) {
                             appendTextToEditor("\n// No data returned from Criminal IP.");
                             return;
@@ -664,7 +664,7 @@
                         onLoadPromptClick: loadPromptMessages,
                         onQueryWhoisClick: queryWhois,
                         onQueryDnsClick: queryDns,
-                        onQueryCitiClick: queryCiti
+                        onQueryIpClick: queryIp
                     }),
                     _e('div', { id: 'container' },
                         _e(Editor, { editorRef }),


### PR DESCRIPTION
Renamed the CitiQuery tool and related files to IpQuery for clarity. Updated all references from CitiApiKey and CitiApiPrefix to CriminalIpApiKey and CriminalIpApiPrefix in code, resources, and UI. Adjusted the editor UI and backend to use the new naming and API configuration.