### PR TITLE
Improve TraceLogger with file-based logging and fallback

### DIFF
--- a/WelsonJS.Toolkit/WelsonJS.Launcher/TraceLogger.cs
+++ b/WelsonJS.Toolkit/WelsonJS.Launcher/TraceLogger.cs
@@ -13,7 +13,7 @@ namespace WelsonJS.Launcher
 {
     /// <summary>
     /// File-based trace logger.
-    /// Writes to %APPDATA%\WelsonJS\Logs\<Namespace>.<random-6>.pid<####>.log
+    /// Writes to %APPDATA%\WelsonJS\Logs\<Namespace>.<random-6>.<PID>.log
     /// Falls back to current directory if %APPDATA%\WelsonJS\Logs cannot be created.
     /// </summary>
     public class TraceLogger : ICompatibleLogger
@@ -42,13 +42,13 @@ namespace WelsonJS.Launcher
                     baseDir = AppDomain.CurrentDomain.BaseDirectory;
                 }
 
-                _logFilePath = Path.Combine(baseDir, $"{ns}.{suffix}.pid{pid}.log");
-
-                var fs = new FileStream(_logFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
-                var writer = new StreamWriter(fs) { AutoFlush = true };
+                _logFilePath = Path.Combine(baseDir, $"{ns}.{suffix}.{pid}.log");
 
                 if (!Trace.Listeners.OfType<TextWriterTraceListener>().Any())
                 {
+                    var fs = new FileStream(_logFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+                    var writer = new StreamWriter(fs) { AutoFlush = true };
+
                     Trace.Listeners.Add(new TextWriterTraceListener(writer)
                     {
                         Name = "FileTraceListener",
@@ -71,12 +71,19 @@ namespace WelsonJS.Launcher
 
         private static string Format(object[] args)
         {
-            if (args == null || args.Length == 0) return string.Empty;
-            if (args.Length == 1) return args[0]?.ToString() ?? string.Empty;
+            if (args == null || args.Length == 0)
+                return string.Empty;
+
+            if (args.Length == 1)
+                return args[0]?.ToString() ?? string.Empty;
 
             string fmt = args[0]?.ToString() ?? string.Empty;
-            try { return string.Format(fmt, args.Skip(1).ToArray()); }
-            catch { return string.Join(" ", args.Select(a => a?.ToString() ?? "")); }
+            try {
+                return string.Format(fmt, args.Skip(1).ToArray());
+            }
+            catch {
+                return string.Join(" ", args.Select(a => a?.ToString() ?? ""));
+            }
         }
 
         private static string GenerateRandomSuffix(int length)


### PR DESCRIPTION
TraceLogger now writes logs to a file in %APPDATA%\WelsonJS\Logs with a randomized suffix and process ID. If the log directory cannot be created, it falls back to the current directory. The logger also improves formatting and random suffix generation for log file names.

## Summary by Sourcery

Enhance TraceLogger to write logs to a file in %APPDATA%\WelsonJS\Logs with randomized suffixes and process IDs, falling back to the current directory or console on errors, and improve log message formatting.

Enhancements:
- Write logs to %APPDATA%\WelsonJS\Logs with filenames including namespace, a random 6-character suffix, and process ID
- Fallback to the application's base directory or console listener if the log directory cannot be created
- Add a single TextWriterTraceListener with DateTime trace options to prevent duplicate listeners
- Implement cryptographically secure random suffix generation for log filenames
- Improve message formatting to handle single arguments and mismatched format placeholders gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Logs are now saved to a dedicated folder in your profile (WelsonJS/Logs) with unique filenames per session/process.
  - New logging actions for info, warnings, and errors are available to callers.

- Bug Fixes
  - Automatic fallback to a local folder if the profile location isn’t available.
  - More resilient startup with console fallback and clearer warnings if file logging fails.
  - Improved message formatting to avoid errors and ensure consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->