### PR TITLE
Rename getFilesFromFolder to getFiles and deprecate old name

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -102,7 +102,7 @@ function includeFile(path) {
     }
 }
 
-function getFilesFromFolder(path) {
+function getFiles(path) {
     if (!folderExists(path)) return [];
 
     var folder = UseObject("Scripting.FileSystemObject", function(fso) {
@@ -110,6 +110,12 @@ function getFilesFromFolder(path) {
     });
 
     return Array.from(folder.Files);
+}
+
+// @deprecated
+function getFilesFromFolder(path) {
+    console.warn("getFilesFromFolder is deprecated");
+    return getFiles(path);
 }
 
 function appendFile(path, content, charset) {
@@ -200,7 +206,7 @@ exports.createFolder = createFolder;
 exports.deleteFolder = deleteFolder;
 exports.deleteFile = deleteFile;
 exports.includeFile = includeFile;
-exports.getFilesFromFolder = getFilesFromFolder;
+exports.getFiles = getFiles;
 exports.appendFile = appendFile;
 exports.rotateFile = rotateFile;
 exports.loadEnvFromFile = loadEnvFromFile;
@@ -208,9 +214,12 @@ exports.loadEnvFromArgs = loadEnvFromArgs;
 exports.normalizePath = normalizePath;
 exports.isAbsolutePath = isAbsolutePath;
 
+// @deprecated
+exports.getFilesFromFolder = getFilesFromFolder;
+
 exports.CdoCharset = PipeIPC.CdoCharset;
 
-exports.VERSIONINFO = "File IO Library (file.js) version 0.2.16";
+exports.VERSIONINFO = "File IO Library (file.js) version 0.2.17";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;


### PR DESCRIPTION
### **User description**
Renamed the getFilesFromFolder function to getFiles for clarity. The original getFilesFromFolder is now marked as deprecated and calls the new function, with a warning. Updated exports to reflect the change and bumped version to 0.2.17.


___

### **PR Type**
Enhancement


___

### **Description**
- Renamed `getFilesFromFolder` to `getFiles` for improved clarity

- Deprecated `getFilesFromFolder` with console warning for backward compatibility

- Updated exports and version to 0.2.17


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getFilesFromFolder"] -- "deprecated" --> B["getFiles"]
  B -- "returns" --> C["Array of files"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file.js</strong><dd><code>Rename function and add deprecation wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/file.js

<ul><li>Renamed <code>getFilesFromFolder</code> function to <code>getFiles</code><br> <li> Added deprecated <code>getFilesFromFolder</code> wrapper with console warning<br> <li> Updated exports to include both new and deprecated function names<br> <li> Bumped version from 0.2.16 to 0.2.17</ul>


</details>


  </td>
  <td><a href="https://github.com/gnh1201/welsonjs/pull/337/files#diff-387904f6b07263914bc1b0cb291a27832cc6963e01b5d44b75460771fc25ee8f">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the public file-listing API to a shorter, consistent name with no behavioral changes.
* **Deprecations**
  * The previous API remains available as a deprecated alias and now emits a warning to aid migration.
* **Chores**
  * Version updated to 0.2.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->