### PR TITLE
Update README.md (Catswords.Phantomizer)

### DIFF
--- a/WelsonJS.Toolkit/Catswords.Phantomizer/README.md
+++ b/WelsonJS.Toolkit/Catswords.Phantomizer/README.md
@@ -9,7 +9,7 @@ It allows your application to fetch and load assemblies directly from your CDN (
 
 ## 🚀 Features
 
-* Load managed (`*.dll`) and native (`*.dll`) assemblies over HTTP
+* Load managed (`*.dll`) and native (`*.dll`) assemblies over HTTP **(HTTPS only)**
 * Optional `.dll.gz` decompression for faster network delivery
 * CDN-friendly URL structure
 * Easy bootstrap through a small embedded loader


### PR DESCRIPTION
Update README.md (Catswords.Phantomizer)

## Summary by Sourcery

Documentation:
- Document that remote assembly loading is restricted to HTTPS endpoints in the Catswords.Phantomizer README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect that loading assemblies now requires HTTPS exclusively; HTTP is no longer supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->