### PR TITLE
Fix #374 (postInstall.ps1)

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -76,6 +76,8 @@ Source: "app\*"; DestDir: "{app}/app"; Flags: ignoreversion recursesubdirs;
 Source: "lib\*"; DestDir: "{app}/lib"; Flags: ignoreversion recursesubdirs;
 ; Source: "bin\*"; Excludes: "installer\*"; DestDir: "{app}/bin"; Flags: ignoreversion recursesubdirs;
 Source: "bin\x86\7zr.exe"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
+Source: "bin\x86\curl.exe"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
+Source: "bin\x86\curl-ca-bundle.crt"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
 Source: "bin\x86\WelsonJS.Launcher.exe"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
 Source: "bin\x86\WelsonJS.Launcher.exe.config"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
 Source: "data\*"; Excludes: "*-apikey.txt"; DestDir: "{app}/data"; Flags: ignoreversion recursesubdirs;


### PR DESCRIPTION
The `Import-PowerShellDataFile` command is not supported in PowerShell 4.0

## Summary by Sourcery

Improve post-install script compatibility and connectivity handling.

Bug Fixes:
- Add TLS 1.0–1.2 protocol configuration in the post-install script to fix connectivity issues on older Windows versions.
- Guard usage of Import-PowerShellDataFile with a fallback that manually loads the .psd1 file for environments where the cmdlet is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled modern TLS (1.2/1.3) with fallback for more reliable downloads.
  * Telemetry now records the actual script name for accurate diagnostics.
  * More resilient download metadata loading for older environments.

* **New Features**
  * Robust archive extraction with layered fallbacks (native tools → bundled extractor), improved tar.gz handling, destination-directory support, safer replace-on-move behavior, and clearer extraction/progress logging.

* **Chores / Installer**
  * Installer now places launcher and supporting binaries in the application folder and updates shortcuts/run entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->