### PR TITLE
Fix logger initialization in ResourceServer constructor

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.Launcher/Properties/AssemblyInfo.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.2.7.58")]
 [assembly: AssemblyFileVersion("0.2.7.58")]
+//[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config", Watch = true)]

--- a/WelsonJS.Augmented/WelsonJS.Launcher/ResourceServer.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/ResourceServer.cs
@@ -52,7 +52,7 @@ namespace WelsonJS.Launcher
         public ResourceServer(string prefix, string resourceName, ILog logger = null)
         {
             // Set the logger
-            _logger = _logger ?? LogManager.GetLogger(typeof(Program));
+            _logger = logger ?? LogManager.GetLogger(typeof(Program));
 
             // Initialize
             _prefix = prefix;


### PR DESCRIPTION
Corrects the logger assignment in ResourceServer to use the provided logger parameter instead of the uninitialized field. Also adds a commented-out log4net configuration line in AssemblyInfo.cs.

## Summary by Sourcery

Fix logger initialization in ResourceServer to respect the injected logger and update assembly metadata with an optional log4net configuration hint.

Bug Fixes:
- Ensure ResourceServer uses the provided logger parameter instead of an uninitialized logger field when constructing the logger instance.

Enhancements:
- Add a commented log4net XmlConfigurator attribute in AssemblyInfo as a reference for optional logging configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal logging configuration adjustments to improve logger initialization handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->