### PR TITLE
Rename install.ps1 to bootstrap.ps1 and update URLs

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,12 +1,12 @@
-# WelsonJS One-Click Installer (install.ps1) 
+# WelsonJS One-Click Bootstrap (bootstrap.ps1)
 # Copyright 2019-2025, Namhyeon Go <gnh1201@catswords.re.kr> and the WelsonJS contributors.
 # SPDX-License-Identifier: GPL-3.0-or-later
 # https://github.com/gnh1201/welsonjs
 # 
 # Usage:
-#   irm https://welson.js.org/install.ps1 | iex
-#   irm https://welson.js.org/install.ps1 | iex -dev main
-#   irm https://welson.js.org/install.ps1 | iex -dev dev
+#   irm https://catswords.blob.core.windows.net/welsonjs/bootstrap.ps1 | iex
+#   irm https://catswords.blob.core.windows.net/welsonjs/bootstrap.ps1 | iex -dev main
+#   irm https://catswords.blob.core.windows.net/welsonjs/bootstrap.ps1 | iex -dev dev
 # 
 # Central default branch configuration for this install script.
 # Update this value if the repository's default branch changes.


### PR DESCRIPTION
## Summary by Sourcery

Rename the PowerShell one-click script to bootstrap.ps1 and update its documented remote execution URLs to the new hosting location.

Enhancements:
- Rebrand the WelsonJS one-click PowerShell script from an installer to a bootstrap script in comments and filename.
- Update usage examples to reference the new blob storage URL for fetching the bootstrap script.