### PR TITLE
Make bootstrap.bat cscript call architecture-aware

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -47,7 +47,7 @@ echo [*] Registering WelsonJS.Toolkit component...
 
 :: Final step
 echo [*] Pre-configuration complete. Starting bootstrap script...
-if /I "%PROCESSOR_ARCHITECTURE%"=="x86" (
+if /I "%PROCESSOR_ARCHITECTURE%%PROCESSOR_ARCHITEW6432%"=="x86" (
     rem 32-bit Windows
     cscript.exe app.js bootstrap
 ) else (

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -47,4 +47,10 @@ echo [*] Registering WelsonJS.Toolkit component...
 
 :: Final step
 echo [*] Pre-configuration complete. Starting bootstrap script...
-%SystemRoot%\SysWOW64\cscript.exe app.js bootstrap
+if /I "%PROCESSOR_ARCHITECTURE%"=="x86" (
+    rem 32-bit Windows
+    cscript.exe app.js bootstrap
+) else (
+    rem 64-bit Windows
+    %SystemRoot%\SysWOW64\cscript.exe app.js bootstrap
+)


### PR DESCRIPTION
Make cscript invocation in bootstrap.bat aware of the OS architecture. On 32-bit Windows (PROCESSOR_ARCHITECTURE==x86) it calls the bundled cscript.exe; on 64-bit it uses %SystemRoot%\SysWOW64\cscript.exe. Prevents attempting to use SysWOW64 on 32-bit systems.

## Summary by Sourcery

Bug Fixes:
- Fix bootstrap script failures on 32-bit Windows by avoiding calls to SysWOW64\cscript.exe and falling back to the local cscript.exe instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows startup compatibility by automatically choosing the correct script host for different system architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->