### PR TITLE
Register ManagedObject and fix cipher ProgID

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -55,6 +55,7 @@ if /I "%PROCESSOR_ARCHITECTURE%%PROCESSOR_ARCHITEW6432%"=="x86" (
     rem 64-bit Windows
 
     echo [*] Registering WelsonJS.ManagedObject component...
+    %REGASM_PATH% /codebase %MANAGEDOBJECT_DLL%
     %REGASM_PATH64% /codebase %MANAGEDOBJECT_DLL%
 
     echo [*] Pre-configuration complete. Starting bootstrap script...

--- a/encryptor.js
+++ b/encryptor.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // https://github.com/gnh1201/welsonjs
 // 
-// HIGHT(ISO/IEC 18033-3) encryption and decryption tool for WelsonJS framework
+// Script encryption and decryption tool for WelsonJS framework
 // 
 var FILE = require("lib/file");
 
@@ -28,7 +28,7 @@ function main(args) {
     }
 
     var data = FILE.readFile(filename, FILE.CdoCharset.CdoUTF_8);
-    var encryptedData = UseObject("WelsonJS.LegacyCipher", function(cipher) {
+    var encryptedData = UseObject("WelsonJS.Legacy.Cipher", function(cipher) {
         return cipher.EncryptString(userKey, data);
     });
 


### PR DESCRIPTION
Add regasm /codebase call in bootstrap.bat to register WelsonJS.ManagedObject DLL during bootstrap. Update encryptor.js comment and correct the UseObject ProgID from "WelsonJS.LegacyCipher" to "WelsonJS.Legacy.Cipher" so the script uses the proper managed object's namespace. Ensures the ManagedObject is registered and encryptor resolves the correct COM object.

## Summary by Sourcery

Register the WelsonJS.ManagedObject COM component during bootstrap and ensure the encryptor script uses the correct managed cipher ProgID.

New Features:
- Register the WelsonJS.ManagedObject DLL via regasm during the bootstrap process.

Bug Fixes:
- Correct the COM ProgID used by encryptor.js to reference WelsonJS.Legacy.Cipher instead of the incorrect WelsonJS.LegacyCipher.

Enhancements:
- Update encryptor.js documentation to describe its role as a general script encryption/decryption tool.