### PR TITLE
Fix artifact package path

### DIFF
--- a/.artifact-configuration.xml
+++ b/.artifact-configuration.xml
@@ -17,7 +17,7 @@
         <authenticode-sign />
       </for-each>
     </pe-file-set>
-    <nupkg-file path="WelsonJS.ManagedObject.*.nupkg">
+    <nupkg-file path="artifacts/WelsonJS.ManagedObject.*.nupkg">
       <directory path="lib">
         <pe-file-set>
           <include path="net20/WelsonJS.ManagedObject.dll" />


### PR DESCRIPTION
Updated the artifact configuration to reference the managed object NuGet package from the artifacts directory instead of the repository root. This keeps the signing and packaging metadata aligned with the actual build output location.

## Summary by Sourcery

Build:
- Adjust NuGet package path in artifact configuration to point to artifacts/WelsonJS.ManagedObject.*.nupkg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the NuGet package path to include the `artifacts/` directory prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->