### PR TITLE
Disable NuGet signing in artifact config

### DIFF
--- a/.artifact-configuration.xml
+++ b/.artifact-configuration.xml
@@ -26,7 +26,7 @@
           </for-each>
         </pe-file-set>
       </directory>
-      <nuget-sign />
+      <!--<nuget-sign />-->
     </nupkg-file>
   </zip-file>
 </artifact-configuration>

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ WelsonJS = ***W***indows + ***El***ectr***on***-like + ***Javascript(JS)*** + :h
 
 **Note**: The default license for this project is GPL 3.0. However, if the GPL 3.0 license is not compatible with Microsoft products, it is subject to the MS-RL license.
 
-## Sponsors
+## Collaborations
 * :octocat: [GitHub Sponsors](https://github.com/sponsors/gnh1201?utm_source=welsonjs), :euro: [Liberapay](https://liberapay.com/catswords?utm_source=welsonjs), :coffee: [Buy me a coffee](https://buymeacoffee.com/catswords?utm_source=welsonjs)
-* <img src="https://catswords.blob.core.windows.net/welsonjs/images/serpapi_logo_32.png" height="32" alt=""/> [SerpApi: Search API](https://serpapi.com/?utm_source=welsonjs) - Scrape search engines results with simple API.
-* <img src="https://catswords.blob.core.windows.net/welsonjs/images/logo_oss.gif" height="32" alt=""/> [Open SW Portal](https://oss.kr/?utm_source=welsonjs), NIPA National IT Industry Promotion Agency<sup>(정보통신산업진흥원)</sup>
-* <img src="https://catswords.blob.core.windows.net/welsonjs/images/signpath_logo.png" height="32" alt=""/> Free code signing provided by [SignPath.io](https://signpath.io/?utm_source=welsonjs), certificate by [SignPath Foundation](https://signpath.org/)
+* <img src="https://catswords.blob.core.windows.net/welsonjs/images/serpapi_logo_32.png" height="32" alt="SerpApi"/> [SerpApi: Search API](https://serpapi.com/?utm_source=welsonjs) - Scrape search engines results with simple API.
+* <img src="https://catswords.blob.core.windows.net/welsonjs/images/logo_oss.gif" height="32" alt="OpenUp"/> [Opensource Portal](https://oss.kr/?utm_source=welsonjs), NIPA National IT Industry Promotion Agency<sup>(정보통신산업진흥원)</sup>
+* <img src="https://catswords.blob.core.windows.net/welsonjs/images/signpath_logo.png" height="32" alt="Signpath"/> Free code signing provided by [SignPath.io](https://signpath.io/?utm_source=welsonjs), certificate by [SignPath Foundation](https://signpath.org/)
+* <img src="https://catswords.blob.core.windows.net/welsonjs/images/cloudbro_logo.png" height="32" alt="Cloudbro"/> ["Ship to Production" Season 3](https://stp.cloudbro.ai/?utm_source=welsonjs) - Selected project
 * Thanks for [F1Security<sup>(에프원시큐리티)</sup>](https://f1security.co.kr/?utm_source=welsonjs) [Microsoft<sup>(ISV Success Program)</sup>](https://www.microsoft.com/en-us/isv/isv-success?utm_source=welsonjs), [Tenstorrent<sup>(Korea OSS Developer Program)</sup>](https://tenstorrent.com/?utm_source=welsonjs), [ReadMe](https://readme.com/?utm_source=welsonjs), [AppSignal](https://www.appsignal.com/)
 
 ## System Requirements


### PR DESCRIPTION
Comment out the NuGet signing step in .artifact-configuration.xml so artifact packaging no longer runs nuget-sign. This adjusts the release artifact configuration to skip signing during generation.

## Summary by Sourcery

Build:
- Update artifact configuration to skip the NuGet signing step during package generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled NuGet package signing during the build process.

* **Documentation**
  * Replaced the Sponsors section with Collaborations.
  * Updated partner descriptions and image alt text.
  * Added Cloudbro’s “Ship to Production” Season 3 entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->