### PR TITLE
Add package README to nuspec

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/Properties/AssemblyInfo.cs
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("A managed object provider for WelsonJS based applications")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Catswords Research")]
-[assembly: AssemblyProduct("WelsonJS.ManagedObject")]
+[assembly: AssemblyProduct("WelsonJS")]
 [assembly: AssemblyCopyright("2026 Namhyeon Go, Catswords OSS and WelsonJS contributors")]
 [assembly: AssemblyTrademark("WelsonJS")]
 [assembly: AssemblyCulture("")]
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      빌드 번호
 //      수정 버전
 //
-[assembly: AssemblyVersion("0.2.7.58")]
-[assembly: AssemblyFileVersion("0.2.7.58")]
+[assembly: AssemblyVersion("0.2.7.60")]
+[assembly: AssemblyFileVersion("0.2.7.60")]

--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/README.md
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/README.md
@@ -2,7 +2,6 @@
 
 Managed Windows COM modules for the [WelsonJS](https://github.com/gnh1201/welsonjs) scripting environment.
 
-**Version:** 0.2.7.58
 **License:** GPL-3.0-only
 **Author:** Catswords Research
 
@@ -170,6 +169,8 @@ Users of **WelsonJS.Toolkit**, including users of WelsonJS **0.2.7.57 and earlie
 
 The functionality previously provided by `WelsonJS.Toolkit` has been migrated to managed COM modules included in this package. New applications should use `WelsonJS.ManagedObject` instead of `WelsonJS.Toolkit`.
 
+If migration is difficult due to compatibility requirements, you can use the `WelsonJS.Legacy.Cipher` and `WelsonJS.Legacy.Toolkit` ProgIDs, which provide compatibility with the existing APIs.
+
 ### Migration summary
 
 | Legacy                           | Replacement                  |
@@ -208,7 +209,6 @@ Contact: [gnh1201@catswords.re.kr](mailto:gnh1201@catswords.re.kr)
 
 * GitHub: https://github.com/gnh1201/welsonjs
 * Package: `WelsonJS.ManagedObject`
-* Version: `0.2.7.58`
 
 ## License
 

--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/welsonjs_managedobject.nuspec
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/welsonjs_managedobject.nuspec
@@ -72,6 +72,7 @@
     <icon>favicon.png</icon>
     <repository type="git" url="https://github.com/gnh1201/welsonjs.git" />
     <license type="expression">GPL-3.0-only</license>
+    <readme>README.md</readme>
 
     <tags>
       WelsonJS Windows COM ActiveX Automation WSH JavaScript IPC Dialog

--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/welsonjs_managedobject.nuspec
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/welsonjs_managedobject.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>WelsonJS.ManagedObject</id>
-    <version>0.2.7.59</version>
+    <version>0.2.7.60</version>
     <authors>Catswords Research</authors>
 
     <title>WelsonJS ManagedObject</title>


### PR DESCRIPTION
Include the package README in the NuGet metadata so it is displayed on the package page. This keeps the managed object package documentation visible to consumers and improves the published package experience.

## Summary by Sourcery

Build:
- Update welsonjs_managedobject.nuspec to reference the package README in its metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for applications requiring legacy API compatibility.
  * Removed version metadata from the project and license documentation.
  * Included the README in the NuGet package metadata.

* **Chores**
  * Updated the package and assembly version to 0.2.7.60.
  * Updated the displayed product name to WelsonJS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->