### PR TITLE
Update IntegrityHashCurl value

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -316,7 +316,7 @@ namespace WelsonJS.Launcher.Properties {
         }
         
         /// <summary>
-        ///   23b24c6a2dc39dbfd83522968d99096fc6076130a6de7a489bc0380cce89143d과(와) 유사한 지역화된 문자열을 찾습니다.
+        ///   5ac5ffa5458c1b10164957f82c1d6d1b8d134598e4c2bcc65083a2b189e18d3d과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
         internal static string IntegrityHashCurl {
             get {

--- a/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.resx
@@ -233,6 +233,6 @@
     <value>https://catswords.blob.core.windows.net/welsonjs/integrity.config.xml</value>
   </data>
   <data name="IntegrityHashCurl" xml:space="preserve">
-    <value>23b24c6a2dc39dbfd83522968d99096fc6076130a6de7a489bc0380cce89143d</value>
+    <value>5ac5ffa5458c1b10164957f82c1d6d1b8d134598e4c2bcc65083a2b189e18d3d</value>
   </data>
 </root>

--- a/WelsonJS.Augmented/WelsonJS.Launcher/app.config
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/app.config
@@ -27,7 +27,7 @@
     <add key="DateTimeFormat" value="yyyy-MM-dd HH:mm:ss" />
     <add key="AssemblyBaseUrl" value="https://catswords.blob.core.windows.net/welsonjs/packages" />
     <add key="AssemblyIntegrityUrl" value="https://catswords.blob.core.windows.net/welsonjs/integrity.config.xml" />
-    <add key="IntegrityHashCurl" value="23b24c6a2dc39dbfd83522968d99096fc6076130a6de7a489bc0380cce89143d" />
+    <add key="IntegrityHashCurl" value="5ac5ffa5458c1b10164957f82c1d6d1b8d134598e4c2bcc65083a2b189e18d3d" />
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />


### PR DESCRIPTION
Update IntegrityHashCurl checksum used for integrity verification. Replaced old hash 23b24c6a2dc39dbfd83522968d99096fc6076130a6de7a489bc0380cce89143d with new hash 5ac5ffa5458c1b10164957f82c1d6d1b8d134598e4c2bcc65083a2b189e18d3d in Resources.resx, Resources.Designer.cs (comment), and app.config (appSettings).

## Summary by Sourcery

Enhancements:
- Align IntegrityHashCurl resource string and app configuration with the new integrity checksum value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the recorded integrity hash for the bundled curl component.
  * Updated the launcher configuration to use the latest verified hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->