### PR TITLE
Integrate AppSignal logging into Launcher

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.Launcher/AppSignalTraceListener.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/AppSignalTraceListener.cs
@@ -230,10 +230,7 @@ namespace WelsonJS.Launcher
                         data.Length);
                 }
 
-                using (WebResponse response =
-                    await request.GetResponseAsync())
-                {
-                }
+                _ = await request.GetResponseAsync();
             }
             catch
             {

--- a/WelsonJS.Augmented/WelsonJS.Launcher/AppSignalTraceListener.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/AppSignalTraceListener.cs
@@ -1,0 +1,359 @@
+﻿// AppSignalTraceListener.cs
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Namhyeon Go <gnh1201@catswords.re.kr>, 2026 Catswords OSS and WelsonJS Contributors
+// https://github.com/gnh1201/welsonjs
+// 
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Reflection;
+using System.Text;
+
+namespace WelsonJS.Launcher
+{
+    public sealed class AppSignalTraceListener : TraceListener
+    {
+        private const string DefaultEndpoint =
+            "https://appsignal-endpoint.net/logs/json";
+
+        private readonly string _endpoint;
+        private readonly string _hostname;
+        private readonly string _group;
+        private readonly string _systemInfo;
+
+        public AppSignalTraceListener(
+            string apiKey,
+            string hostname = null,
+            string group = null,
+            string endpoint = null)
+        {
+            _hostname = string.IsNullOrEmpty(hostname)
+                ? Environment.MachineName
+                : hostname;
+
+            _group = string.IsNullOrEmpty(group)
+                ? "welsonjs"
+                : group;
+
+            _endpoint = BuildEndpoint(
+                string.IsNullOrEmpty(endpoint)
+                    ? DefaultEndpoint
+                    : endpoint,
+                apiKey);
+
+            _systemInfo = BuildSystemInfo();
+        }
+
+        private static string BuildEndpoint(
+            string endpoint,
+            string apiKey)
+        {
+            if (string.IsNullOrEmpty(endpoint))
+                return null;
+
+            if (string.IsNullOrEmpty(apiKey))
+                return null;
+
+            return endpoint
+                + "?api_key="
+                + Uri.EscapeDataString(apiKey);
+        }
+
+        private string BuildSystemInfo()
+        {
+            var process = Process.GetCurrentProcess();
+
+            string processName = "unknown";
+
+            try
+            {
+                processName = process.ProcessName;
+            }
+            catch
+            {
+                // Ignore process information failures.
+            }
+
+            string applicationVersion = "unknown";
+
+            try
+            {
+                Assembly assembly = Assembly.GetEntryAssembly();
+
+                if (assembly != null)
+                {
+                    AssemblyName assemblyName = assembly.GetName();
+
+                    if (assemblyName.Version != null)
+                        applicationVersion =
+                            assemblyName.Version.ToString();
+                }
+            }
+            catch
+            {
+                // Ignore version detection failures.
+            }
+
+            string processArchitecture =
+                Environment.Is64BitProcess
+                    ? "x64"
+                    : "x86";
+
+            string osArchitecture =
+                Environment.Is64BitOperatingSystem
+                    ? "x64"
+                    : "x86";
+
+            return
+                "\"machine_name\":" +
+                JsonString(Environment.MachineName) + "," +
+
+                "\"os_version\":" +
+                JsonString(Environment.OSVersion.ToString()) + "," +
+
+                "\"os_architecture\":" +
+                JsonString(osArchitecture) + "," +
+
+                "\"process_architecture\":" +
+                JsonString(processArchitecture) + "," +
+
+                "\"process_name\":" +
+                JsonString(processName) + "," +
+
+                "\"process_id\":" +
+                process.Id + "," +
+
+                "\"runtime_version\":" +
+                JsonString(Environment.Version.ToString()) + "," +
+
+                "\"application_version\":" +
+                JsonString(applicationVersion);
+        }
+
+        public override void Write(string message)
+        {
+            Send("info", message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            Send("info", message);
+        }
+
+        public override void TraceEvent(
+            TraceEventCache eventCache,
+            string source,
+            TraceEventType eventType,
+            int id,
+            string message)
+        {
+            Send(
+                GetSeverity(eventType),
+                message);
+        }
+
+        public override void TraceEvent(
+            TraceEventCache eventCache,
+            string source,
+            TraceEventType eventType,
+            int id,
+            string format,
+            params object[] args)
+        {
+            string message;
+
+            try
+            {
+                message = string.Format(format, args);
+            }
+            catch
+            {
+                message = format;
+            }
+
+            Send(
+                GetSeverity(eventType),
+                message);
+        }
+
+        private void Send(
+            string severity,
+            string message)
+        {
+            if (string.IsNullOrEmpty(_endpoint))
+                return;
+
+            if (message == null)
+                message = string.Empty;
+
+            try
+            {
+                string json = BuildLogMessage(
+                    severity,
+                    message);
+
+                _ = SendHttpAsync(json);
+            }
+            catch
+            {
+                // Logging must never affect the application.
+            }
+        }
+
+        private async System.Threading.Tasks.Task SendHttpAsync(
+            string json)
+        {
+            try
+            {
+                string payload = json + "\n";
+
+                byte[] data =
+                    Encoding.UTF8.GetBytes(payload);
+
+                var request =
+                    (HttpWebRequest)
+                    WebRequest.Create(_endpoint);
+
+                request.Method = "POST";
+                request.ContentType = "application/x-ndjson";
+                request.Accept = "application/json";
+                request.ContentLength = data.Length;
+                request.Timeout = 5000;
+
+                using (Stream stream =
+                    await request.GetRequestStreamAsync())
+                {
+                    await stream.WriteAsync(
+                        data,
+                        0,
+                        data.Length);
+                }
+
+                using (WebResponse response =
+                    await request.GetResponseAsync())
+                {
+                }
+            }
+            catch
+            {
+                // Never allow logging failures to affect the application.
+            }
+        }
+
+        private string BuildLogMessage(
+            string severity,
+            string message)
+        {
+            string timestamp =
+                DateTime.UtcNow.ToString(
+                    "yyyy-MM-dd'T'HH:mm:ss.fff'Z'");
+
+            return
+                "{"
+                + "\"timestamp\":"
+                + JsonString(timestamp)
+                + ",\"group\":"
+                + JsonString(_group)
+                + ",\"severity\":"
+                + JsonString(severity)
+                + ",\"message\":"
+                + JsonString(message)
+                + ",\"hostname\":"
+                + JsonString(_hostname)
+                + ",\"attributes\":{"
+                + _systemInfo
+                + "}"
+                + "}";
+        }
+
+        private static string GetSeverity(
+            TraceEventType eventType)
+        {
+            switch (eventType)
+            {
+                case TraceEventType.Critical:
+                    return "fatal";
+
+                case TraceEventType.Error:
+                    return "error";
+
+                case TraceEventType.Warning:
+                    return "warn";
+
+                case TraceEventType.Verbose:
+                    return "debug";
+
+                case TraceEventType.Information:
+                default:
+                    return "info";
+            }
+        }
+
+        private static string JsonString(
+            string value)
+        {
+            if (value == null)
+                return "null";
+
+            var builder =
+                new StringBuilder();
+
+            builder.Append('"');
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+
+                switch (c)
+                {
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+
+                    default:
+                        if (c < 0x20)
+                        {
+                            builder.Append("\\u");
+                            builder.Append(
+                                ((int)c).ToString("x4"));
+                        }
+                        else
+                        {
+                            builder.Append(c);
+                        }
+
+                        break;
+                }
+            }
+
+            builder.Append('"');
+
+            return builder.ToString();
+        }
+    }
+}

--- a/WelsonJS.Augmented/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Program.cs
@@ -36,6 +36,16 @@ namespace WelsonJS.Launcher
             // Display a message box whenever Trace.TraceError() is called.
             Trace.Listeners.Add(new MessageBoxTraceListener());
 
+            // AppSignal (Error Tracking & Performance Monitoring) integration
+            // Free AppSingal plan for open-source projects: https://www.appsignal.com/open-source?utm_source=welsonjs
+            string appSignalApiPrefix = GetAppConfig("AppSignalApiPrefix");
+            string appSignalApiKey = GetAppConfig("AppSignalApiKey");
+            if (string.IsNullOrEmpty(appSignalApiKey))
+            {
+                Trace.Listeners.Add(new AppSignalTraceListener(
+                    appSignalApiKey, null, "WelsonJS.Launcher", appSignalApiPrefix));
+            }
+
             // get the date time format
             _dateTimeFormat = GetAppConfig("DateTimeFormat");
 

--- a/WelsonJS.Augmented/WelsonJS.Launcher/Program.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Program.cs
@@ -40,7 +40,7 @@ namespace WelsonJS.Launcher
             // Free AppSingal plan for open-source projects: https://www.appsignal.com/open-source?utm_source=welsonjs
             string appSignalApiPrefix = GetAppConfig("AppSignalApiPrefix");
             string appSignalApiKey = GetAppConfig("AppSignalApiKey");
-            if (string.IsNullOrEmpty(appSignalApiKey))
+            if (!string.IsNullOrEmpty(appSignalApiKey))
             {
                 Trace.Listeners.Add(new AppSignalTraceListener(
                     appSignalApiKey, null, "WelsonJS.Launcher", appSignalApiPrefix));

--- a/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.Designer.cs
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace WelsonJS.Launcher.Properties {
         }
         
         /// <summary>
+        ///   ls-9e36eee5-ba13-45cd-a7d1-b19f39329173과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string AppSignalApiKey {
+            get {
+                return ResourceManager.GetString("AppSignalApiKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   https://appsignal-endpoint.net/logs/json과(와) 유사한 지역화된 문자열을 찾습니다.
+        /// </summary>
+        internal static string AppSignalApiPrefix {
+            get {
+                return ResourceManager.GetString("AppSignalApiPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   https://catswords.blob.core.windows.net/welsonjs/packages과(와) 유사한 지역화된 문자열을 찾습니다.
         /// </summary>
         internal static string AssemblyBaseUrl {

--- a/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.resx
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/Properties/Resources.resx
@@ -235,4 +235,10 @@
   <data name="IntegrityHashCurl" xml:space="preserve">
     <value>5ac5ffa5458c1b10164957f82c1d6d1b8d134598e4c2bcc65083a2b189e18d3d</value>
   </data>
+  <data name="AppSignalApiPrefix" xml:space="preserve">
+    <value>https://appsignal-endpoint.net/logs/json</value>
+  </data>
+  <data name="AppSignalApiKey" xml:space="preserve">
+    <value>ls-9e36eee5-ba13-45cd-a7d1-b19f39329173</value>
+  </data>
 </root>

--- a/WelsonJS.Augmented/WelsonJS.Launcher/WelsonJS.Launcher.csproj
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/WelsonJS.Launcher.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiEndpoints\JsonRpc2.cs" />
+    <Compile Include="AppSignalTraceListener.cs" />
     <Compile Include="AssemblyLoader.cs" />
     <Compile Include="IApiEndpoint.cs" />
     <Compile Include="JsCore.cs" />

--- a/WelsonJS.Augmented/WelsonJS.Launcher/app.config
+++ b/WelsonJS.Augmented/WelsonJS.Launcher/app.config
@@ -24,6 +24,8 @@
     <add key="IpQueryApiPrefix" value="https://api.criminalip.io/v1/" />
     <add key="IpQueryApiKey2" value="" />
     <add key="IpQueryApiPrefix2" value="https://api.abuseipdb.com/api/v2/" />
+    <add key="AppSignalApiPrefix" value="https://appsignal-endpoint.net/logs/json"/>
+    <add key="AppSignalApiKey" value="ls-9e36eee5-ba13-45cd-a7d1-b19f39329173"/>
     <add key="DateTimeFormat" value="yyyy-MM-dd HH:mm:ss" />
     <add key="AssemblyBaseUrl" value="https://catswords.blob.core.windows.net/welsonjs/packages" />
     <add key="AssemblyIntegrityUrl" value="https://catswords.blob.core.windows.net/welsonjs/integrity.config.xml" />


### PR DESCRIPTION
Add AppSignal error/performance logging to WelsonJS.Launcher. Introduces AppSignalTraceListener (NDJSON POSTs to an AppSignal endpoint, non-blocking and fail-safe), registers the listener in Program.cs, and adds AppSignalApiPrefix/AppSignalApiKey entries to Resources.resx and app.config. Also includes the new source file in the csproj. Enables optional remote logging with a default endpoint and sample API key.

## Summary by Sourcery

Integrate optional remote error and performance logging into WelsonJS.Launcher via an AppSignal trace listener.

New Features:
- Add AppSignalTraceListener to send trace output as NDJSON to a remote AppSignal-compatible endpoint.
- Expose AppSignalApiPrefix and AppSignalApiKey as configurable resources and app settings for enabling remote logging.

Enhancements:
- Register the AppSignal trace listener in the launcher startup so application traces can be forwarded without impacting normal execution.
- Include the new trace listener source file in the project so it is built with WelsonJS.Launcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional AppSignal-compatible error and diagnostic logging.
  * Log entries include application, runtime, operating system, and process details.
  * Supports configurable endpoint, API key, hostname, and group values.
  * Safely formats messages and maps diagnostic events to severity levels.
  * Logging and network failures do not interrupt application operation.
* **Configuration**
  * Added application settings for enabling and configuring AppSignal logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->