### PR TITLE
Bundle runtime DLLs in installer

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -1,5 +1,5 @@
 ; @created_on 2020-06-26
-; @updated_on 2026-08-05
+; @updated_on 2026-08-17
 ; @author Namhyeon Go <gnh1201@catswords.re.kr> and Catswords OSS contributors.
 
 [Setup]

--- a/setup.iss
+++ b/setup.iss
@@ -80,6 +80,10 @@ Source: "bin\x86\curl.exe"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recur
 Source: "bin\x86\curl-ca-bundle.crt"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
 Source: "bin\x86\WelsonJS.Launcher.exe"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
 Source: "bin\x86\WelsonJS.Launcher.exe.config"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
+Source: "bin\x86\WelsonJS.Esent.dll"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
+Source: "bin\x86\WelsonJS.ManagedObject.dll"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
+Source: "bin\x86\Catswords.Phantomizer.dll"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
+Source: "bin\x86\ChakraCore.dll"; DestDir: "{app}/bin/x86"; Flags: ignoreversion recursesubdirs;
 Source: "data\*"; Excludes: "*-apikey.txt"; DestDir: "{app}/data"; Flags: ignoreversion recursesubdirs;
 ; Source: "node_modules\*"; DestDir: "{app}/node_modules"; Flags: ignoreversion recursesubdirs;
 ; Source: "bower_components\*"; DestDir: "{app}/node_modules"; Flags: ignoreversion recursesubdirs;


### PR DESCRIPTION
Updated setup.iss to include the required x86 runtime assemblies for the packaged app: WelsonJS.Esent, WelsonJS.ManagedObject, Catswords.Phantomizer, and ChakraCore. This ensures the installed application ships with its native dependencies and can run correctly without missing DLLs.

## Summary by Sourcery

Build:
- Update Inno Setup configuration to include WelsonJS.Esent, WelsonJS.ManagedObject, Catswords.Phantomizer, and ChakraCore DLLs in the x86 binary directory.