### PR TITLE
Document SZDDComp compatibility header

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/External/SZDDComp.cs
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/External/SZDDComp.cs
@@ -1,4 +1,6 @@
 ﻿/*
+ * SZDDComp: Microsoft "compress.exe/expand.exe" compatible compressor
+ *
  * The original copyright information for SZDDComp could not be fully recovered.
  * Therefore, all individuals and organizations identified as possible contributors
  * to the source code have been acknowledged below.


### PR DESCRIPTION
Add a source header to SZDDComp clarifying that it is a Microsoft compress.exe/expand.exe compatible compressor. This improves code provenance and helps future maintainers understand the file's purpose and origin.

## Summary by Sourcery

Enhancements:
- Document SZDDComp as compatible with Microsoft's compress.exe and expand.exe utilities and clarify its source provenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive compatibility information for the SZDD compression component, including Microsoft `compress.exe` and `expand.exe`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->