### PR TITLE
Fix advisory GHSA-9jmm-5v6v-gpq2

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.Service/ServiceMain.cs
+++ b/WelsonJS.Augmented/WelsonJS.Service/ServiceMain.cs
@@ -49,6 +49,10 @@ namespace WelsonJS.Service
             args = _args;
             logger = _logger;
 
+            // get the program files directory
+            var programFiles = Environment.GetFolderPath(
+                Environment.SpecialFolder.ProgramFiles);
+
             // mapping arguments to each variables
             var arguments = ParseArguments(this.args);
             foreach (KeyValuePair<string, string> entry in arguments)
@@ -56,7 +60,12 @@ namespace WelsonJS.Service
                 switch (entry.Key)
                 {
                     case "working-directory":
-                        workingDirectory = entry.Value;
+                        // Temporary mitigation for GHSA-9jmm-5v6v-gpq2.
+                        // Services must use the trusted installation directory instead of a fallback path.
+                        // Additional path and integrity validation will be added in a future release.
+                        workingDirectory = Environment.UserInteractive
+                            ? entry.Value
+                            : Path.Combine(programFiles, applicationName);
                         break;
 
                     case "script-name":
@@ -87,7 +96,19 @@ namespace WelsonJS.Service
             // set working directory
             if (string.IsNullOrEmpty(workingDirectory))
             {
-                workingDirectory = Path.Combine(Path.GetTempPath(), applicationName);
+                if (Environment.UserInteractive)
+                {
+                    // Temporary mitigation for GHSA-9jmm-5v6v-gpq2.
+                    // Allow the temporary directory only for interactive execution.
+                    workingDirectory = Path.Combine(Path.GetTempPath(), applicationName);
+                }
+                else
+                {
+                    // Temporary mitigation for GHSA-9jmm-5v6v-gpq2.
+                    // Services must never fall back to a user-writable temporary directory.
+                    workingDirectory = Path.Combine(programFiles, applicationName);
+                }
+
                 logger.LogInformation("Working directory not provided. Using default value: " + workingDirectory);
 
                 if (!Directory.Exists(workingDirectory))

--- a/installService.bat
+++ b/installService.bat
@@ -6,6 +6,10 @@ REM https://github.com/gnh1201/welsonjs
 REM Set the service name
 set SERVICE_NAME=WelsonJS.Service
 
+REM Get the current directory
+set CURRENT_DIR=%~dp0
+set CURRENT_DIR=%CURRENT_DIR:~0,-1%
+
 REM Set the paths
 set EXE_PATH=%APPDATA%\welsonjs\bin\WelsonJS.Service.exe
 set INSTALL_UTIL_PATH=%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe


### PR DESCRIPTION
Fix advisory GHSA-9jmm-5v6v-gpq2

## Summary by Sourcery

Restrict service working directories to the trusted Program Files installation path while preserving temporary-directory behavior for interactive execution.

Bug Fixes:
- Prevent non-interactive services from using user-writable temporary or caller-supplied working directories, mitigating GHSA-9jmm-5v6v-gpq2.

Build:
- Prepare the service installer script to track the installation directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service execution directory handling for more reliable operation.
  * Non-interactive services now consistently run from the trusted installation directory.
  * Interactive execution preserves temporary-directory behavior when no working directory is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->