### PR TITLE
Update version and service metadata

### DIFF
--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/Properties/AssemblyInfo.cs
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      빌드 번호
 //      수정 버전
 //
-[assembly: AssemblyVersion("0.2.7.60")]
-[assembly: AssemblyFileVersion("0.2.7.60")]
+[assembly: AssemblyVersion("0.2.7.61")]
+[assembly: AssemblyFileVersion("0.2.7.61")]

--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/README.md
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/README.md
@@ -17,6 +17,7 @@ The package extends WelsonJS with Windows-specific capabilities such as:
 * Mouse and keyboard input simulation
 * Window handle manipulation
 * Bitmap and image information extraction
+* Microsoft Compress (MSCOMP/SZDD) compression and decompression
 
 The managed object functionality is automatically initialized by the WelsonJS `app.js` runtime and is available globally. Users do not need to explicitly create a `WelsonJS.ManagedObject` instance.
 
@@ -85,6 +86,20 @@ Example:
 ```javascript
 UseObject("WelsonJS.BitmapControl", function(bitmapControl) {
     // Inspect bitmap and image information here.
+});
+```
+
+### `WelsonJS.MsCompress`
+
+Provides Microsoft Compress (MSCOMP/SZDD) compression and decompression functionality for WelsonJS applications.
+
+This module can be used to work with legacy Microsoft compressed files and SZDD-compressed data.
+
+Example:
+
+```javascript
+UseObject("WelsonJS.MsCompress", function(msCompress) {
+    // Compress or decompress data here.
 });
 ```
 
@@ -158,6 +173,7 @@ The following modules are included:
 | `WelsonJS.NamedSharedMemory` | Named shared memory IPC             |
 | `WelsonJS.ProcessControl`    | Mouse, keyboard, and window control |
 | `WelsonJS.BitmapControl`     | Bitmap and image information        |
+| `WelsonJS.MsCompress`         | Microsoft Compress / SZDD support   |
 
 WSH-provided `Scripting.*`, `ADODB.*`, and `WScript.*` objects are **not included** in `WelsonJS.ManagedObject` and remain outside the scope of this package.
 

--- a/WelsonJS.Augmented/WelsonJS.ManagedObject/welsonjs_managedobject.nuspec
+++ b/WelsonJS.Augmented/WelsonJS.ManagedObject/welsonjs_managedobject.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>WelsonJS.ManagedObject</id>
-    <version>0.2.7.60</version>
+    <version>0.2.7.61</version>
     <authors>Catswords Research</authors>
 
     <title>WelsonJS ManagedObject</title>
@@ -16,8 +16,9 @@
       WelsonJS.ManagedObject provides managed COM modules for the WelsonJS
       scripting environment. These modules extend WelsonJS with Windows-specific
       capabilities such as COM object activation, dialogs, inter-process
-      communication, input simulation, window handling, and bitmap information
-      extraction.
+      communication, input simulation, window handling, bitmap information
+      extraction, and Microsoft Compress (MSCOMP/SZDD) compression and
+      decompression.
 
       Included COM modules:
 
@@ -41,12 +42,16 @@
       Provides bitmap and image information utilities, including image size
       and pixel information extraction.
 
+      - WelsonJS.MsCompress
+      Provides Microsoft Compress (MSCOMP/SZDD) compression and decompression
+      functionality for working with legacy Microsoft compressed files.
+
       - WelsonJS.Legacy.Cipher (for compatibility only)
-      
+
       - WelsonJS.Legacy.Toolkit (for compatibility only)
 
       Migration:
-      
+
       Users of WelsonJS.Toolkit, including users of WelsonJS version 0.2.7.57
       and earlier, should migrate to WelsonJS.ManagedObject.
 
@@ -59,11 +64,11 @@
       environment and may depend on Windows-specific COM and system APIs.
 
       Developer:
-      
+
       Namhyeon Go (WelsonJS Maintainer)
 
       Contact:
-      
+
       gnh1201@catswords.re.kr
 
       #OPENTOWORK

--- a/WelsonJS.Augmented/WelsonJS.Service/Properties/AssemblyInfo.cs
+++ b/WelsonJS.Augmented/WelsonJS.Service/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // 제어됩니다. 어셈블리와 관련된 정보를 수정하려면
 // 이러한 특성 값을 변경하세요.
 [assembly: AssemblyTitle("WelsonJS.Service")]
-[assembly: AssemblyDescription("Windows Service for WelsonJS framework based applications")]
+[assembly: AssemblyDescription("A service provider for WelsonJS based applications")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Catswords")]
+[assembly: AssemblyCompany("Catswords Research")]
 [assembly: AssemblyProduct("WelsonJS")]
-[assembly: AssemblyCopyright("2025 Catswords OSS and WelsonJS Contributors")]
+[assembly: AssemblyCopyright("2026 Namhyeon Go, Catswords OSS and WelsonJS Contributors")]
 [assembly: AssemblyTrademark("WelsonJS")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // 모든 값을 지정하거나 아래와 같이 '*'를 사용하여 빌드 번호 및 수정 번호를
 // 기본값으로 할 수 있습니다.
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.7.55")]
-[assembly: AssemblyFileVersion("0.2.7.55")]
+[assembly: AssemblyVersion("0.2.7.61")]
+[assembly: AssemblyFileVersion("0.2.7.61")]

--- a/setup.iss
+++ b/setup.iss
@@ -110,7 +110,7 @@ Filename: {app}\uninstallService.bat; Components: artifacts; Flags: waituntilter
 
 [CustomMessages]
 AppName=WelsonJS
-AppVersion=0.2.7.57
+AppVersion=0.2.7.61
 PostHogApiKey=phc_pmRHJ0aVEhtULRT4ilexwCjYpGtE9VYRhlA05fwiYt8
 
 [Code]


### PR DESCRIPTION
This change bumps the WelsonJS.ManagedObject and WelsonJS.Service assembly versions from 0.2.7.55/60 to 0.2.7.61. It also updates the service assembly metadata, including the description, company name, and copyright text to reflect the current branding and attribution.

## Summary by Sourcery

Update WelsonJS component versions and service metadata while documenting Microsoft Compress support.

New Features:
- Document Microsoft Compress (MSCOMP/SZDD) compression and decompression support in the managed object package.

Enhancements:
- Refresh WelsonJS.Service assembly metadata to reflect current service description, company, and attribution.

Build:
- Align managed object, service, and installer versions at 0.2.7.61.

Documentation:
- Add usage and module reference documentation for WelsonJS.MsCompress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for Microsoft Compress/SZDD compression and decompression through the `WelsonJS.MsCompress` module.
* **Chores**
  * Updated application and package version information to `0.2.7.61`.
  * Refreshed service metadata, including its description, company attribution, and copyright details.
  * Added the compression module to the included modules list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->