### PR TITLE
Fix bugs and bump versions in core modules

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -65,7 +65,7 @@ function ArchiveObject(engine) {
             // create the directives file (temporary file)
             var tmp = PipeIPC.connect("volatile");
             tmp.write(directives);
-            var tmp_path = out.path;
+            var tmp_path = tmp.path;
             tmp.close();
             
             // compress to cab
@@ -120,7 +120,7 @@ exports.create = function(engine) {
     return new ArchiveObject(engine);
 };
 
-exports.VERSIONINFO = "File archiver library (archive.js) version 0.1-dev";
+exports.VERSIONINFO = "File archiver library (archive.js) version 0.1.1";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;

--- a/lib/powershell.js
+++ b/lib/powershell.js
@@ -50,8 +50,8 @@ var PowershellObject = function() {
     //   data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==
     this.loadURI = function(uri) {
         var pos = uri.indexOf(':');
-        var scheme = (pos < 0 ? '' : url.substring(0, pos));
-        var target = (pos < 0 ? uri : url.substring(pos + 1));
+        var scheme = (pos < 0 ? '' : uri.substring(0, pos));
+        var target = (pos < 0 ? uri : uri.substring(pos + 1));
 
         switch (scheme) {
             case 'http':
@@ -152,7 +152,7 @@ exports.execScript = execScript;
 exports.execCommand = execCommand;
 exports.runAs = runAs;
 
-exports.VERSIONINFO = "Powershell Interface (powershell.js) version 0.1.4";
+exports.VERSIONINFO = "Powershell Interface (powershell.js) version 0.1.5";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -79,7 +79,7 @@ var XMLObject = function(dom) {
         }
     };
     
-    this.eq = function() {
+    this.eq = function(i) {
         if (this.nodes.length > i) {
             return this.nodes[i];
         }
@@ -139,6 +139,6 @@ exports.load = load;
 exports.encode = encode;
 exports.decode = decode;
 
-exports.VERSIONINFO = "XML interface (xml.js) version 0.2.4";
+exports.VERSIONINFO = "XML interface (xml.js) version 0.2.5";
 exports.global = global;
 exports.require = global.require;

--- a/uriloader.js
+++ b/uriloader.js
@@ -74,7 +74,7 @@ function main(args) {
                 ]);
                 break;
 
-            dafault:
+            default:
                 console.log("Unknown application");
         }
 


### PR DESCRIPTION
Fix several small but critical bugs and update module version strings:

- lib/archive.js: use tmp.path for temporary directives file (was referencing out.path) and bump to 0.1.1.
- lib/powershell.js: correct URI parsing to use `uri` (not `url`) and bump to 0.1.5.
- lib/xml.js: restore eq(i) parameter to index nodes correctly and bump to 0.2.5.
- uriloader.js: fix switch-case typo `dafault` -> `default`.

These changes address correctness/regression issues in core utilities.

## Summary by Sourcery

Fix core utility regressions and update affected module versions.

Bug Fixes:
- Fix temporary directive file handling in the archive utility.
- Correct URI parsing in the PowerShell interface.
- Restore indexed XML node selection and correct URI loader fallback handling.

Chores:
- Update version identifiers for the archive, PowerShell, and XML core modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CAB archive creation.
  * Corrected PowerShell URI parsing.
  * Fixed XML comparison behavior.
  * Ensured unrecognized applications display the appropriate fallback message.

* **Chores**
  * Updated archive, PowerShell, and XML component version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->