### PR TITLE
Add orcarouter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Open to work](https://img.shields.io/badge/%23-OPENTOWORK-green?utm_source=welsonjs)](https://github.com/gnh1201/welsonjs/discussions/167?utm_source=welsonjs)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg?utm_source=welsonjs)](https://deepwiki.com/gnh1201/welsonjs?utm_source=welsonjs)
 [![MCP](https://img.shields.io/badge/-MCP-black?logo=modelcontextprotocol&utm_source=welsonjs)](https://github.com/gnh1201/welsonjs/wiki/MCP-server?utm_source=welsonjs)
+[![Powered by OrcaRouter](https://img.shields.io/badge/Powered_by-OrcaRouter-2563eb)](https://www.orcarouter.ai/ref/ref_52d30a71b6fb8416d0fc)
 
 <img src="https://catswords.blob.core.windows.net/welsonjs/images/logo.svg?utm_source=welsonjs" height="32" alt="WelsonJS logo with four diagonal stripes in red, green, blue, and yellow, overlaid with the letters JS."/> WelsonJS - Build a Windows app on the Windows built-in JavaScript engine.
 

--- a/data/apikey.json
+++ b/data/apikey.json
@@ -13,5 +13,6 @@
     "scrapeops": "file:data/scrapeops_apikey.txt",
     "serpapi": "file:data/serpapi_apikey.txt",
     "aviationstack": "file:data/aviationstack_apikey.txt",
-    "abuseipdb": "file:data/abuseipdb_apikey.txt"
+    "abuseipdb": "file:data/abuseipdb_apikey.txt",
+    "orcarouter": "file:data/orcarouter_apikey.txt"
 }

--- a/lib/language-inference-engine.js
+++ b/lib/language-inference-engine.js
@@ -541,7 +541,7 @@ var ENGINE_PROFILES = {
             "Content-Type": "application/json",
             "Authorization": "Bearer {apikey}"
         },
-        "url": "https://api.orcarouter.ai/v1",
+        "url": "https://api.orcarouter.ai/v1/chat/completions",
         "wrap": function(model, message, temperature) {
             return {
                 "model": model,

--- a/lib/language-inference-engine.js
+++ b/lib/language-inference-engine.js
@@ -531,6 +531,45 @@ var ENGINE_PROFILES = {
                 }, []);
             }
         }
+    },
+    "orcarouter": {
+        "type": "llm",
+        "availableModels": [
+            "orcarouter/auto"
+        ],
+        "headers": {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer {apikey}"
+        },
+        "url": "https://api.orcarouter.ai/v1",
+        "wrap": function(model, message, temperature) {
+            return {
+                "model": model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": BIAS_MESSAGE
+                    },
+                    {
+                        "role": "user",
+                        "content": message
+                    }
+                ],
+                "temperature": temperature,
+                "stream": false
+            };
+        },
+        "callback": function(response) {
+            if ("error" in response) {
+                return ["Error: " + response.error.message];
+            } else {
+                return response.choices.reduce(function(a, x) {
+                    a.push(x.message.content);
+                    
+                    return a;
+                }, []);
+            }
+        }
     }
 };
 
@@ -613,7 +652,7 @@ exports.create = function() {
     return new LanguageInferenceEngine();
 };
 
-exports.VERSIONINFO = "Language Inference Engine integration version 0.1.12";
+exports.VERSIONINFO = "Language Inference Engine integration version 0.1.13";
 exports.AUTHOR = "gnh1201@catswords.re.kr";
 exports.global = global;
 exports.require = global.require;


### PR DESCRIPTION
Add orcarouter integration

https://www.orcarouter.ai/ref/ref_52d30a71b6fb8416d0fc

## Summary by Sourcery

Integrate OrcaRouter into the language inference engine as an available LLM provider.

New Features:
- Add OrcaRouter as a supported language inference provider using its chat completions API.

Enhancements:
- Update the language inference integration version to 0.1.13.

Documentation:
- Add a Powered by OrcaRouter attribution badge to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OrcaRouter support for chat-based language inference with automatic model selection.
  - Added bearer-token authentication for OrcaRouter requests.
  - Added configuration support for supplying an OrcaRouter API key.

- **Documentation**
  - Added a “Powered by OrcaRouter” badge linking to the OrcaRouter website.

- **Chores**
  - Updated the integration version from 0.1.12 to 0.1.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->